### PR TITLE
[WIP] Create token & set Strapi permissions automatically

### DIFF
--- a/backend/vaa-strapi/src/functions/generate-frontend-token.ts
+++ b/backend/vaa-strapi/src/functions/generate-frontend-token.ts
@@ -1,0 +1,49 @@
+export async function generateFrontendToken(strapi) {
+  const tokenService = strapi.service('admin::api-token');
+  if (tokenService && tokenService.create) {
+    const tokenAlreadyExists = await tokenService.exists({
+      name: 'vaa-frontend-token',
+    });
+    if (tokenAlreadyExists) {
+      const token = await tokenService.find({
+        name: 'vaa-frontend-token',
+      });
+      console.log('token: ', token);
+      console.info('an api token named \'vaa-frontend-token\' already exists, skipping...');
+    }
+    else {
+      console.info('creating \'vaa-frontend-token\' api token');
+      const { accessKey } = await tokenService.create({
+        name: 'vaa-frontend-token',
+        type: 'custom',
+        permissions:[
+          'api::answer.answer.find',
+          'api::answer.answer.findOne',
+          'api::candidate.candidate.find',
+          'api::candidate.candidate.findOne',
+          'api::candidate-answer.candidate-answer.find',
+          'api::candidate-answer.candidate-answer.findOne',
+          'api::category.category.find',
+          'api::category.category.findOne',
+          'api::constituency.constituency.find',
+          'api::constituency.constituency.findOne',
+          'api::election.election.find',
+          'api::election.election.findOne',
+          'api::language.language.find',
+          'api::language.language.findOne',
+          'api::party.party.find',
+          'api::party.party.findOne',
+          'api::question.question.find',
+          'api::question.question.findOne',
+          'plugin::upload.content-api.find',
+          'plugin::upload.content-api.findOne',
+          'plugin::i18n.locales.listLocales',
+        ],
+      });
+      console.log('Token: ', accessKey);
+    }
+  }else {
+    console.error('Can\'t check if token exists');
+  }
+  return;
+}

--- a/backend/vaa-strapi/src/functions/set-frontend-permissions.ts
+++ b/backend/vaa-strapi/src/functions/set-frontend-permissions.ts
@@ -1,0 +1,72 @@
+/**
+ * Creates a new permissions object for Strapi if permission does not exist,
+ * and returns said object for later to be added into a role.
+ * @param route
+ * @param permission
+ */
+async function createPermissionObject(route: string, permission: string ){
+  const action = `${route}::${permission}`;
+  const existingPermission = await strapi.query('plugin::users-permissions.permission').findOne({ where: { action: action }});
+
+  if(!existingPermission){
+    const permissionObj = await strapi.query('plugin::users-permissions.permission').create({
+      data: {
+        action: action
+      }
+    });
+    if(permissionObj){
+      console.info('Created new permission for ', permission);
+    } else {
+      console.error('Could not create permission for ', permission);
+    }
+    return permissionObj;
+  } else {
+    return existingPermission;
+  }
+}
+
+/**
+ * Enables the permissions required by frontend API queries
+ * in Strapi users-permissions plugin whenever server starts.
+ */
+export async function setFrontendPermissions(){
+  const publicRole = await strapi
+    .query('plugin::users-permissions.role')
+    .findOne({where: {type: 'authenticated'}, populate: ['users', 'permissions']});
+
+  const requiredPermissions = [
+    'answer',
+    'candidate',
+    'candidate-answer',
+    'category',
+    'constituency',
+    'election',
+    'language',
+    'party',
+    'question',
+  ];
+
+  const permissions = [];
+  // for (const permission of requiredPermissions) {
+  //   const findPermissionObj = await createPermissionObject('api', `${permission}.${permission}.find`);
+  //   permissions.push(findPermissionObj);
+  //
+  //   const findOnePermissionObj = await createPermissionObject('api', `${permission}.${permission}.findOne`);
+  //   permissions.push(findOnePermissionObj);
+  // }
+
+  const uploadFindPermissionObj = await createPermissionObject('plugin', 'upload.content-api.find');
+  permissions.push(uploadFindPermissionObj);
+
+  const uploadFindOnePermissionObj = await createPermissionObject('plugin', 'upload.content-api.findOne');
+  permissions.push(uploadFindOnePermissionObj);
+
+  const languagesPermissionObj = await createPermissionObject('plugin', 'i18n.locales.listLocales');
+  permissions.push(languagesPermissionObj);
+
+  // await strapi.query('plugin::users-permissions.role').update({
+  //   where: {id: publicRole.id},
+  //   data: {permissions: permissions},
+  // });
+  return;
+}

--- a/backend/vaa-strapi/src/index.ts
+++ b/backend/vaa-strapi/src/index.ts
@@ -1,5 +1,7 @@
 'use strict';
-/* import {Strapi} from '@strapi/strapi'; */
+import {setFrontendPermissions} from './functions/set-frontend-permissions';
+import {generateFrontendToken} from './functions/generate-frontend-token';
+import {Strapi} from '@strapi/strapi';
 
 module.exports = {
   /**
@@ -8,7 +10,8 @@ module.exports = {
    *
    * This gives you an opportunity to extend code.
    */
-  register(/*{strapi}: {strapi: Strapi}*/) {
+  // eslint-disable-next-line no-empty-pattern
+  register({strapi}: {strapi: Strapi}) {
     // ...
   },
 
@@ -19,5 +22,8 @@ module.exports = {
    * This gives you an opportunity to set up your data model,
    * run jobs, or perform some special logic.
    */
-  bootstrap(/*{ strapi }*/) {}
+  bootstrap() {
+    generateFrontendToken(strapi)
+    setFrontendPermissions();
+  }
 };


### PR DESCRIPTION
## WHY:
Automating the process of creating a Strapi token, so user don't have to set everything themselves.

Fixes #46

TODO:
- Think of way of passing Token automatically to frontend. Maybe shared file between containers which the frontend reads?

### What has been changed (if possible, add screenshots, gifs, etc. )

## Check off each of the following tasks as they are completed

- [ ] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/documentation/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have added documentation where necessary.
- [X] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
