### PR TITLE
fix: Don't run workflows if only documentation is changed

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - '**/*/.env.example'
   pull_request:
     types:
       - opened
@@ -12,6 +15,9 @@ on:
       - ready_for_review
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - '**/*/.env.example'
 
 jobs:
   frontend-validation:

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - qa
+    paths-ignore:
+      - '**.md'
+      - '**/*/.env.example'
   pull_request:
     types:
       - opened
@@ -12,6 +15,9 @@ on:
       - ready_for_review
     branches:
       - qa
+    paths-ignore:
+      - '**.md'
+      - '**/*/.env.example'
 
 jobs:
   frontend-validation:

--- a/backend/vaa-strapi/README.md
+++ b/backend/vaa-strapi/README.md
@@ -32,8 +32,6 @@ This feature is only enabled in development builds and is mostly intended to ass
 **Please keep in mind that setting this variable as true will clear the database contents of existing candidates, parties, elections, and so on and should only be used for debugging purposes.**
 Setting `GENERATE_MOCK_DATA_ON_RESTART` as true will override `GENERATE_MOCK_DATA_ON_INITIALISE` setting.
 
----
-
 ## Official documentation from Strapi
 
 Strapi comes with a fully featured [Command Line Interface](https://docs.strapi.io/developer-docs/latest/developer-resources/cli/CLI.html) (CLI) which lets you scaffold and manage your project in seconds.

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -64,6 +64,12 @@ On top of that, the commit message should follow the following rules:
 Once your changes are ready, don't forget to [self-review](self-review.md) to speed up the review
 process.
 
+### Workflows
+The project uses GitHub Actions to verify each commit passes unit tests, is able to 
+build the app successfully and adheres to the [coding conventions used by the project](style-guides.md).
+If a commit fails the verification, please check your changes from the logs and fix changes before
+submitting a review request.
+
 ### Pull Request
 
 When you're done with the changes, create a pull request known as a PR.
@@ -76,6 +82,7 @@ When you're done with the changes, create a pull request known as a PR.
   your PR. Either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request)
   or pull request comments.
 - As you update your PR and apply changes, mark each conversation as [resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations).
+- Make sure that your commits pass the validation workflows, are able to run tests & build the application.
 
 ### Your PR is merged!
 


### PR DESCRIPTION
## WHY:
Doesn't run Github workflows on commits that have only documentation files changed, as there are no changes to build or test. Improved documentation about running workflows.

### What has been changed (if possible, add screenshots, gifs, etc. )

## Check off each of the following tasks as they are completed

- [ ] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
