### PR TITLE
fix: Format description text numbers properly in questions intro page

### DIFF
--- a/frontend/src/routes/(voters)/questions/+page.svelte
+++ b/frontend/src/routes/(voters)/questions/+page.svelte
@@ -1,15 +1,21 @@
 <script lang="ts">
-  import {_} from 'svelte-i18n';
   import {page} from '$app/stores';
 
   const firstQuestionUrl = `${$page.url.pathname.replace(/\/$/, '')}/${$page.data.questions[0].id}`;
+
+  const questionCategories = new Set<string>();
+  $page.data.questions.forEach((question: any) => questionCategories.add(question?.category));
+
+  const opinionsDescriptionText = $page.data.appLabels.viewTexts.yourOpinionsDescription
+    .replace('{{0}}', $page.data.questions.length.toString())
+    .replace('{{1}}', questionCategories.size.toString());
 </script>
 
 <div class="flex max-w-xl flex-grow flex-col justify-center p-lg">
   <h1 class="my-lg">
     {$page.data.appLabels.viewTexts.yourOpinionsTitle}
   </h1>
-  <p class="text-center">{$page.data.appLabels.viewTexts.yourOpinionsDescription}</p>
+  <p class="text-center">{opinionsDescriptionText}</p>
   <a href={firstQuestionUrl} class="btn-primary btn"
     >{$page.data.appLabels.actionLabels.startQuestions}</a>
 </div>

--- a/frontend/src/routes/(voters)/questions/+page.svelte
+++ b/frontend/src/routes/(voters)/questions/+page.svelte
@@ -4,7 +4,9 @@
   const firstQuestionUrl = `${$page.url.pathname.replace(/\/$/, '')}/${$page.data.questions[0].id}`;
 
   const questionCategories = new Set<string>();
-  $page.data.questions.forEach((question: any) => questionCategories.add(question?.category));
+  $page.data.questions.forEach((question) => {
+    if (question.category) questionCategories.add(question.category);
+  });
 
   const opinionsDescriptionText = $page.data.appLabels.viewTexts.yourOpinionsDescription
     .replace('{{0}}', $page.data.questions.length.toString())


### PR DESCRIPTION
## WHY:

Small fix to make questions intro page text look nicer for the demo. Replaces {{0}} and {(1}} with actual numbers based on the number of questions

### What has been changed (if possible, add screenshots, gifs, etc. )
Page layout on questions page.

## Check off each of the following tasks as they are completed

- [X] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [X] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
