### PR TITLE
docs: add security to self review and remove style

### DIFF
--- a/docs/contributing/self-review.md
+++ b/docs/contributing/self-review.md
@@ -4,9 +4,8 @@ You should always review your own PR first before assigning a reviewer to it. Be
 you should check before submitting your PR.
 
 - [ ] Confirm that the changes solve the issue you are trying to solve partially or fully.
+- [ ] Review the code in terms of the [OWASP top 10 security issues](https://owasp.org/Top10/).
 - [ ] Verify that your unit tests are running successfully.
 - [ ] Review your changes by yourself before assigning a reviewer to the pull request. This will help you spot issues
       like typos, content that doesn't follow the style guide or content that is added by mistake.
-- [ ] Adhere to the [style guides](style-guides.md). Most style guidelines are enforced by prettier, but you must 
-  double-check that your changes follow the style guide used in this project.
 - [ ] If there are any failing checks in your PR, troubleshoot them until they're all passing.


### PR DESCRIPTION
As discussed in the Aalto SWP 1 sprint 0 meeting,
checking the code for most common cyber security
issues is now included in self review.

Because `style-guides.md` is currently empty,
it's removed from the checklist but should be
reintroduced once we have such a guide.

## WHY:

Decided in the Aalto SWP 1 sprint 0 meeting.

### What has been changed (if possible, add screenshots, gifs, etc. )

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
