### PR TITLE
Use docker volume over bind mounts for postgres

### DIFF
--- a/backend/vaa-strapi/docker-compose.dev.yml
+++ b/backend/vaa-strapi/docker-compose.dev.yml
@@ -39,7 +39,7 @@ services:
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
     volumes:
-      - ./data:/var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
     ports:
       - '5432:5432'
     restart: always
@@ -49,3 +49,6 @@ services:
     restart: always
     ports:
       - '4567:8080'
+
+volumes:
+  postgres:

--- a/backend/vaa-strapi/docker-compose.yml
+++ b/backend/vaa-strapi/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
     volumes:
-      - ./data:/var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
     ports:
       - '5432:5432'
     restart: always
@@ -42,3 +42,6 @@ services:
     restart: always
     ports:
       - '4567:8080'
+
+volumes:
+  postgres:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,3 +38,6 @@ services:
       POSTGRES_DB: ${DATABASE_NAME}
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+
+volumes:
+  postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,3 +37,6 @@ services:
       POSTGRES_DB: ${DATABASE_NAME}
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+
+volumes:
+  postgres:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "scripts": {
-        "dev":"docker compose -f docker-compose.dev.yml up -d --build",
-        "dev:attach":"docker compose -f docker-compose.dev.yml up --build",
+        "dev":"docker compose -f docker-compose.dev.yml up -d --force-recreate --build",
+        "dev:attach":"docker compose -f docker-compose.dev.yml up --force-recreate --build",
         "dev:down": "docker compose -f docker-compose.dev.yml down -v --remove-orphans",
         "dev:stop": "docker compose -f docker-compose.dev.yml stop",
         "prepare":"husky install",


### PR DESCRIPTION
## WHY:

Currently, some people have issues with starting the project due to the Postgres container's data folder having changed ownership due to mismatching users between the host and the container. This leads to people having to run "chmod -R 777" each time when testing some of the changes.

### What has been changed (if possible, add screenshots, gifs, etc. )

The bind mount has been replaced with volumes so that Docker will be fully responsible for figuring out the folder's correct permissions. Additionally, I've added `--force-recreate` flag for the dev commands so that `.env` and docker compose changes always propagate.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
