### PR TITLE
fix: Make candidate app login work on production build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,5 @@ GENERATE_MOCK_DATA_ON_RESTART=false
 
 # Frontend dependencies
 VITE_BACKEND_URL=http://strapi:1337
-VITE_PUBLIC_BACKEND_URL=http://localhost:1337
+PUBLIC_BACKEND_URL=http://localhost:1337
 VITE_STRAPI_TOKEN=

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
       - "strapi"
     environment:
       - VITE_BACKEND_URL=${VITE_BACKEND_URL}
-      - VITE_PUBLIC_BACKEND_URL=${VITE_PUBLIC_BACKEND_URL}
+      - PUBLIC_BACKEND_URL=${PUBLIC_BACKEND_URL}
       - VITE_STRAPI_TOKEN=${VITE_STRAPI_TOKEN}
   strapi:
     extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "strapi"
     environment:
       - VITE_BACKEND_URL=${VITE_BACKEND_URL}
-      - VITE_PUBLIC_BACKEND_URL=${VITE_PUBLIC_BACKEND_URL}
+      - PUBLIC_BACKEND_URL=${PUBLIC_BACKEND_URL}
       - VITE_STRAPI_TOKEN=${VITE_STRAPI_TOKEN}
   strapi:
     extends:

--- a/frontend/src/lib/utils/constants.ts
+++ b/frontend/src/lib/utils/constants.ts
@@ -1,6 +1,7 @@
+import {env} from '$env/dynamic/public';
+
 export const constants: Record<string, string> = {
   BACKEND_URL: import.meta.env.VITE_BACKEND_URL || process.env.VITE_BACKEND_URL || '',
-  PUBLIC_BACKEND_URL:
-    import.meta.env.VITE_PUBLIC_BACKEND_URL || process.env.VITE_PUBLIC_BACKEND_URL || '',
+  PUBLIC_BACKEND_URL: env.PUBLIC_BACKEND_URL || '', // Accessed by the client-side, so must be loaded dynamically
   STRAPI_TOKEN: import.meta.env.VITE_STRAPI_TOKEN || process.env.VITE_STRAPI_TOKEN || ''
 };


### PR DESCRIPTION
## WHY:

Logging into candidate app did not work on production build, as built Svelte app was unable to access the backend URL and send login info. Received error:
```
5.febffbc8.js:1 Uncaught (in promise) TypeError: Failed to construct 'URL': Invalid URL
    at dr (5.febffbc8.js:1:4074)
    at Object._r [as logIn] (5.febffbc8.js:1:4680)
    at HTMLFormElement.d (5.febffbc8.js:7:6045)
    at HTMLFormElement.<anonymous> (index.acd0945c.js:1:3560)
```
This error was because the URL given was undefined. You can see this error in action in https://demo.openvaa.org/candidate

### What has been changed (if possible, add screenshots, gifs, etc. )
Changed how backend URL environment variable is imported so it is accessible by the client-side app as well.

To test the changes, set environment variables correctly as in the PR files, run `npm run prod`, go to http://localhost/candidate and verify that you are still able to login to the application successfully.p

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
