### PR TITLE
fix: modal is visible in dark mode

### DIFF
--- a/frontend/src/lib/components/navigation/Navigation.svelte
+++ b/frontend/src/lib/components/navigation/Navigation.svelte
@@ -63,8 +63,9 @@
       <button class="btn-glass btn-primary btn w-full" on:click={closeModal}
         >{$_('candidateApp.navbar.continueEnteringData')}</button>
       <div class="h-4" />
-      <button class="btn-outline btn-error btn w-full" on:click={logout}
-        >{$_('candidateApp.navbar.logOut')}</button>
+      <button
+        class="btn-outline btn-error btn w-full dark:bg-white dark:bg-opacity-10"
+        on:click={logout}>{$_('candidateApp.navbar.logOut')}</button>
     </div>
   </TimedModal>
   <input id="sidebar" type="checkbox" class="drawer-toggle" bind:checked />

--- a/frontend/src/lib/components/navigation/Navigation.svelte
+++ b/frontend/src/lib/components/navigation/Navigation.svelte
@@ -48,7 +48,7 @@
     bind:closeModal
     onTimeout={logout}
     timerDuration={logoutModalTimer}>
-    <div class="notification text-center text-black">
+    <div class="notification text-center">
       <h1>Some Of Your Data Is Still Missing</h1>
       <br />
       <p>
@@ -60,10 +60,10 @@
         seconds.
       </p>
       <br />
-      <button class="btn-glass btn btn-primary w-full" on:click={closeModal}
+      <button class="btn-glass btn-primary btn w-full" on:click={closeModal}
         >{$_('candidateApp.navbar.continueEnteringData')}</button>
       <div class="h-4" />
-      <button class="btn btn-error btn-outline w-full" on:click={logout}
+      <button class="btn-outline btn-error btn w-full" on:click={logout}
         >{$_('candidateApp.navbar.logOut')}</button>
     </div>
   </TimedModal>
@@ -72,7 +72,7 @@
     <!-- Navbar -->
     <div class="navbar w-full bg-base-300">
       <div class="flex-none">
-        <button aria-label="open sidebar" class="btn btn-square btn-ghost" on:click={handleClick}>
+        <button aria-label="open sidebar" class="btn-ghost btn-square btn" on:click={handleClick}>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -84,7 +84,7 @@
       <div class="mx-2 flex-1 px-2">PubLogo</div>
       <div class="flex-none">
         {#if $user}
-          <button class="btn btn-ghost btn-lg" on:click={triggerLogout}
+          <button class="btn-ghost btn-lg btn" on:click={triggerLogout}
             >{$_('candidateApp.navbar.logOut')}</button>
         {/if}
       </div>
@@ -96,7 +96,7 @@
     <label for="sidebar" aria-label="close sidebar" class="drawer-overlay" />
     <ul class="menu h-full w-fit bg-base-200 p-4">
       <!-- Sidebar content here -->
-      <button aria-label="close sidebar" class="btn btn-square btn-ghost" on:click={handleClick}>
+      <button aria-label="close sidebar" class="btn-ghost btn-square btn" on:click={handleClick}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           class="h-24 w-24"

--- a/frontend/src/lib/components/navigation/TimedModal.svelte
+++ b/frontend/src/lib/components/navigation/TimedModal.svelte
@@ -80,7 +80,7 @@
   };
 </script>
 
-<dialog bind:this={modalContainer} class="modal">
+<dialog bind:this={modalContainer} class="modal dark:bg-white dark:bg-opacity-10">
   <div class="modal-box">
     <slot />
     <progress


### PR DESCRIPTION
## WHY:

Fixes https://github.com/orgs/OpenVAA/projects/2/views/1?pane=issue&itemId=45145874

### What has been changed (if possible, add screenshots, gifs, etc. )

Timed modal text was black even in dark mode, making it invisible. Now the text is white and the modal is more visible in general.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
