### PR TITLE
fix: users permissions race condition when initializing for the first time

### DIFF
--- a/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
+++ b/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
@@ -8,7 +8,7 @@ const defaultAuthenticatedPermissions = [
 module.exports = async (plugin) => {
   const origBootstrap = plugin.bootstrap;
   plugin.bootstrap = async (ctx) => {
-    const res = origBootstrap(ctx);
+    const res = await origBootstrap(ctx);
 
     const pluginStore = strapi.store({type: 'plugin', name: 'users-permissions'});
 


### PR DESCRIPTION
## WHY:

Currently, when initializing the app for the first time there's a race condition with the users-permissions plugin due to missing `await` causing some of the data not to be created yet and as a result trying to edit non-existent data, leading to the app not starting up.

### What has been changed (if possible, add screenshots, gifs, etc. )

Added a missing `await`.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
