### PR TITLE
feat/refactor: add darkMode store and only render one image in the AppLogo template part

### DIFF
--- a/frontend/src/lib/templates/parts/appLogo/AppLogo.svelte
+++ b/frontend/src/lib/templates/parts/appLogo/AppLogo.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import normalLogo from './svg/openvaa-logo-grey.svg';
-  import inverseLogo from './svg/openvaa-logo-white.svg';
+  import {darkMode} from '$lib/utils/darkMode';
   import type {AppLogoProps} from './AppLogo.type';
 
   type $$Props = AppLogoProps;
@@ -26,8 +25,11 @@
   // Merge classes into restProps
   $$restProps.class = `${classes} ${$$restProps.class ?? ''}`;
 
+  // Check dark mode and select logo file
+  let logo: string;
+  $: logo = $darkMode || inverse ? 'openvaa-logo-white' : 'openvaa-logo-grey';
+
   // TODO: Use logo files defined in Strapi.
-  // TODO: Render only one image, see issue #279
 </script>
 
 <!--
@@ -57,6 +59,7 @@ colour changes dynamically based on whether the light or dark mode is active.
 -->
 
 <div {...$$restProps}>
-  <img src={normalLogo} {alt} class="h-full {inverse ? 'hidden dark:block' : 'dark:hidden'}" />
-  <img src={inverseLogo} {alt} class="h-full {inverse ? 'dark:hidden' : 'hidden dark:block'}" />
+  {#await import(`./svg/${logo}.svg`) then logoSrc}
+    <img src={logoSrc.default} {alt} class="h-full" />
+  {/await}
 </div>

--- a/frontend/src/lib/templates/parts/appLogo/AppLogo.svelte
+++ b/frontend/src/lib/templates/parts/appLogo/AppLogo.svelte
@@ -27,7 +27,8 @@
 
   // Check dark mode and select logo file
   let logo: string;
-  $: logo = $darkMode || inverse ? 'openvaa-logo-white' : 'openvaa-logo-grey';
+  $: logo =
+    ($darkMode && !inverse) || (!$darkMode && inverse) ? 'openvaa-logo-white' : 'openvaa-logo-grey';
 
   // TODO: Use logo files defined in Strapi.
 </script>

--- a/frontend/src/lib/utils/darkMode.ts
+++ b/frontend/src/lib/utils/darkMode.ts
@@ -1,0 +1,27 @@
+// Defines a store getting the user's dark mode preference
+// For a more comprehensive mediaQuery solution, see
+// https://github.com/fedorovvvv/svelte-media-queries
+
+import {readable, type Readable} from 'svelte/store';
+import {logDebugError} from './logger';
+
+/**
+ * The value of this store is `true` if the user prefers dark mode.
+ * In order to work, the `window` object must be available.
+ *
+ * @default false
+ */
+export const darkMode: Readable<boolean> = readable(false, (set) => {
+  if (!window) {
+    logDebugError('The darkMode store cannot be accessed before window is available!');
+    return () => void 0;
+  }
+  const query = window.matchMedia('(prefers-color-scheme: dark)');
+  const updateDarkMode = (query: MediaQueryList | MediaQueryListEvent) => set(query.matches);
+  // Set initial value
+  updateDarkMode(query);
+  // Listen for changes
+  query.addEventListener('change', updateDarkMode);
+  // Remove the listener when there are no subscribers to the store
+  return () => query.removeEventListener('change', updateDarkMode);
+});

--- a/frontend/src/routes/_test/+page.svelte
+++ b/frontend/src/routes/_test/+page.svelte
@@ -2,5 +2,7 @@
   import {AppLogo} from '$lib/templates/parts/appLogo';
 </script>
 
-<AppLogo alt="" />
-<a href="/_test/2">asa</a>
+<div class="bg-base-300">
+  Normal: <AppLogo alt="" />
+  Inverse: <AppLogo alt="" inverse />
+</div>

--- a/frontend/src/routes/_test/+page.svelte
+++ b/frontend/src/routes/_test/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import {AppLogo} from '$lib/templates/parts/appLogo';
+</script>
+
+<AppLogo alt="" />
+<a href="/_test/2">asa</a>

--- a/frontend/src/routes/_test/2/+page.svelte
+++ b/frontend/src/routes/_test/2/+page.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+</script>
+
+aa

--- a/frontend/src/routes/_test/2/+page.svelte
+++ b/frontend/src/routes/_test/2/+page.svelte
@@ -1,4 +1,0 @@
-<script lang="ts">
-</script>
-
-aa


### PR DESCRIPTION
## WHY:

Fixes #279 

### What has been changed (if possible, add screenshots, gifs, etc. )

Add `darkMode` store which can be used to check if the user prefers the dark mode.

Use this in the `AppLogo` template part to select which logo image to render.

### Preview

Go to `_test` and change between dark and light mode from preferences (System Settings > Appearance on Mac).

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
