### PR TITLE
fix: color contrast issues globally

### DIFF
--- a/docs/frontend/color-test.txt
+++ b/docs/frontend/color-test.txt
@@ -1,0 +1,37 @@
+<script lang="ts">
+  // To test all of the application's colors, copy paste this as a `+page.svelte` file
+  // somewhere, navigate to it and use the Wave browser extension to check the colors.
+  // Remember to do this for both the light and dark modes.
+  //
+  // We need to spell all the complete color names out so that the classes will be compiled.
+  // For that reason this file should not be included in any production build with a suffix
+  // that is included in `tailwind.config.cjs`:
+  //   `content: ['./src/**/*.{html,js,svelte,ts}']`
+  const textColors = ['text-primary', 'text-secondary', 'text-accent', 'text-neutral', 'text-info', 'text-success', 'text-warning', 'text-error'];
+  const bgColors = ['bg-base-100', 'bg-base-200', 'bg-base-300'];
+  const contentColors = ['text-base-content', 'text-primary-content', 'text-secondary-content', 'text-accent-content', 'text-info-content', 'text-success-content', 'text-warning-content', 'text-error-content'];
+  const contentBgs = ['bg-base', 'bg-primary', 'bg-secondary', 'bg-accent', 'bg-info', 'bg-success', 'bg-warning', 'bg-error'];
+  const contentPairs = contentColors.map((c, i) => [contentBgs[i], c]);
+</script>
+
+<h1>Colors and combinations</h1>
+
+{#each bgColors as bgColor}
+  <h2 class="my-lg">Background: {bgColor}</h2>
+  <div class="p-lg {bgColor}">
+    {#each textColors as textColor}
+      <div class="mt-lg first:mt-0 {textColor}">
+        <p>Text: {textColor}</p>
+      </div>
+    {/each}
+  </div>
+{/each}
+
+{#each contentPairs as [bgColor, textColor]}
+  <h2 class="my-lg">Background: {bgColor}</h2>
+  <div class="p-lg {bgColor}">
+    <div class="mt-lg first:mt-0 {textColor}">
+      <p>Text: {textColor}</p>
+    </div>
+  </div>
+{/each}

--- a/docs/frontend/styling.md
+++ b/docs/frontend/styling.md
@@ -10,6 +10,8 @@ The reason for limiting Tailwind classes is that this way adherence to the desig
 
 Note that you can still use [arbitrary values](https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values) with any Tailwind utility class with the bracket notation, e.g. `w-[21.35px]`. Bear in mind, however, that you should not construct these (or any other Tailwind classes) in code, unless the whole final string for the class is spelled out in code, such as `class = 'w-' + size === 'lg' ? 'lg' : 'md'`, because Tailwind only compiles classes it can spot in the source code using a naïve search.
 
+## Colors
+
 For DaisyUI, all the [basic colours](https://daisyui.com/docs/colors/) are defined for both the default and the dark theme, which is used in dark mode. The colours are applicable to Tailwind utility classes (e.g. `text-primary`, `bg-base-300`) and DaisyUI component classes (e.g. `btn-primary`). You can see all the colours in `tailwind.config.cjs` but the most common ones are listed below.
 
 |                                                                                                                       | Name            | Use                                                                   |
@@ -20,9 +22,21 @@ For DaisyUI, all the [basic colours](https://daisyui.com/docs/colors/) are defin
 |  <div style="background: #a82525; width: 1.5rem; height: 1.5rem;"/>                                                   | `warning`       | For warnings and actions demanding caution                            |
 |  <div style="background: #a82525; width: 1.5rem; height: 1.5rem;"/>                                                   | `error`         | For errors                                                            |
 |  <div style="background: #ffffff; outline: 1px solid #666666; outline-offset: -1px; width: 1.5rem; height: 1.5rem;"/> | `base-100`      | Default background                                                    |
-|  <div style="background: #a82525; width: 1.5rem; height: 1.5rem;"/>                                                   | `base-200`      | Slightly less prominent shaded background                             |
+|  <div style="background: #e8f5f6; width: 1.5rem; height: 1.5rem;"/>                                                   | `base-200`      | Slightly less prominent shaded background                             |
 |  <div style="background: #d1ebee; width: 1.5rem; height: 1.5rem;"/>                                                   | `base-300`      | Default prominent background                                          |
 |  <div style="background: #ffffff; outline: 1px solid #2546a8; outline-offset: -1px; width: 1.5rem; height: 1.5rem;"/> | primary-content | Text on `bg-primary`. Each colour has its associated `content` colour |
+
+### Color contrast
+
+In order to fulfil the application's accessibility requirements, a [WGAC AA level color contrast](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) has to be reached. The colors have been defined to ensure this as long as:
+* If the background is any of the base colors, e.g. `bg-base-100`, `bg-base-200` or `bg-base-300`, you can use any of the basic text colors on it.
+* If background is any other color, such as `bg-primary`, always use the matching `content` color for text on it, e.g.  `text-primary-content`.
+
+### Testing the colors
+
+To test all of the application's colors, copy-paste the contents of [`color-test.txt`](./color-test.txt) in a `+page.svelte` file somewhere, navigate to it and use the Wave browser extension to check the colors. Remember to do this for both the light and dark modes.
+
+The file is not included anywhere as a ready Svelte file, because otherwise all of the color classes in it would unnecessarily be compiled into the application by Tailwind.
 
 ## Default styling
 

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -177,12 +177,12 @@ module.exports = {
           // DaisyUI colors: https://daisyui.com/docs/colors/
           'primary':   '#2546a8', // = success
           'secondary': '#666666',
-          'accent':    '#0d827c', // = info
+          'accent':    '#0a716b', // = info
           'neutral':   '#333333',
           'base-100':  '#ffffff',
           'base-200':  '#e8f5f6', // 50% tint of base-300 on base-100
           'base-300':  '#d1ebee', // Remember to match this with the theme-color in app.html
-          'info':      '#0d827c', // = accent (var() cannot be used in these)
+          'info':      '#0a716b', // = accent (var() cannot be used in these)
           'success':   '#2546a8', // = primary
           'warning':   '#a82525', // = error
           'error':     '#a82525', // = warning
@@ -214,16 +214,16 @@ module.exports = {
           'base-300':  '#1f2324', // Remember to match this with the theme-color in app.html
           'info':      '#11a8a0', // = accent (var() cannot be used in these)
           'success':   '#6887e3', // = primary
-          'warning':   '#d72f2f', // = error
-          'error':     '#d72f2f', // = warning
+          'warning':   '#e16060', // = error
+          'error':     '#e16060', // = warning
           'base-content':      '#cccccc', // = neutral
           'primary-content':   '#000000',
           'secondary-content': '#000000',
           'accent-content':    '#000000',
-          'info-content':      '#000000', // = accent-content
-          'success-content':   '#000000', // = primary-content
-          'warning-content':   '#ffffff',
-          'error-content':     '#ffffff', // = warning-content
+          'info-content':      '#000000',
+          'success-content':   '#000000',
+          'warning-content':   '#000000',
+          'error-content':     '#000000',
 
           // Other DaisyUI variables
           ...themeCSSVars,

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -180,7 +180,7 @@ module.exports = {
           'accent':    '#0d827c', // = info
           'neutral':   '#333333',
           'base-100':  '#ffffff',
-          'base-200':  '#e5e5e5',
+          'base-200':  '#e8f5f6', // 50% tint of base-300 on base-100
           'base-300':  '#d1ebee', // Remember to match this with the theme-color in app.html
           'info':      '#0d827c', // = accent (var() cannot be used in these)
           'success':   '#2546a8', // = primary
@@ -210,7 +210,7 @@ module.exports = {
           'accent':    '#11a8a0', // = info
           'neutral':   '#cccccc',
           'base-100':  '#000000',
-          'base-200':  '#1a1a1a',
+          'base-200':  '#101212', // 50% tint of base-300 on base-100
           'base-300':  '#1f2324', // Remember to match this with the theme-color in app.html
           'info':      '#11a8a0', // = accent (var() cannot be used in these)
           'success':   '#6887e3', // = primary


### PR DESCRIPTION
## WHY:

Fixes #285 

### What has been changed (if possible, add screenshots, gifs, etc. )

1. Some color definitions are changed so that all the normal color combinations have AA-level contrast.
2. Redefined the `base-200` color to match Figma designs.
3. Added information about testing the color contrasts to `docs/frontend` as well as a file that can be used to test them.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
