### PR TITLE
feat: match basic information UI to Figma

### DIFF
--- a/frontend/src/lib/components/common/FieldGroup.svelte
+++ b/frontend/src/lib/components/common/FieldGroup.svelte
@@ -5,9 +5,9 @@
 
 <div class="w-full">
   <slot name="header" field={undefined} />
-  <div class="my-6 flex w-full flex-col gap-4 overflow-hidden rounded-lg">
+  <div class="my-6 flex w-full flex-col gap-2 overflow-hidden rounded-lg">
     {#each fields as field}
-      <div class="bg-base-300" style={customStyle}>
+      <div class="bg-base-100" style={customStyle}>
         <slot {field} />
       </div>
     {/each}

--- a/frontend/src/routes/candidate/profile/+page.svelte
+++ b/frontend/src/routes/candidate/profile/+page.svelte
@@ -89,9 +89,6 @@
     <FieldGroup>
       <label for="message" class={disclaimerClass} slot="header"
         >{$_('candidateApp.basicInfo.electionManifesto')}</label>
-      <!-- <p class={disclaimerClass} slot="header">
-        {$_('candidateApp.basicInfo.electionManifesto')}
-      </p> -->
       <textarea id="message" rows="4" class="w-full resize-none bg-base-100 p-6 !outline-none" />
     </FieldGroup>
   </div>

--- a/frontend/src/routes/candidate/profile/+page.svelte
+++ b/frontend/src/routes/candidate/profile/+page.svelte
@@ -14,81 +14,85 @@
     ['motherTongue', ['English', 'Suomi', 'Svenska']]
   ]);
 
-  const labelClass = 'label-sm label mx-6 my-2';
+  const labelClass = 'label-sm label mx-6 my-2 text-secondary';
   const disclaimerClass = 'm-0 p-0 text-sm text-secondary';
 </script>
 
-<div class="mx-40 my-20 flex flex-col items-center gap-20">
-  <h2>{$_('candidateApp.basicInfo.title')}</h2>
+<div class="bg-base-200">
+  <div class="mx-40 my-20 flex flex-col items-center gap-20">
+    <h2>{$_('candidateApp.basicInfo.title')}</h2>
 
-  <p class="text-center">
-    {$_('candidateApp.basicInfo.instructions')}
-  </p>
-
-  <FieldGroup fields={disabledFields} let:field>
-    <div class="flex items-center justify-between px-4">
-      <label for={field} class={labelClass}>
-        {$_(`candidateApp.basicInfo.fields.${field}`)}
-      </label>
-      <input
-        type="text"
-        id={field}
-        placeholder="PLACEHOLDER"
-        class="input input-ghost input-sm w-6/12 text-right" />
-    </div>
-    <p class={disclaimerClass} slot="footer">
-      {$_('candidateApp.basicInfo.disclaimer')}
+    <p class="text-center">
+      {$_('candidateApp.basicInfo.instructions')}
     </p>
-  </FieldGroup>
 
-  <FieldGroup fields={editableFields} let:field>
-    <div class="flex items-center justify-between px-4">
-      <label for={field} class={labelClass}>
-        {$_(`candidateApp.basicInfo.fields.${field}`)}
-      </label>
-      {#if field === 'age'}
+    <FieldGroup fields={disabledFields} let:field>
+      <div class="flex items-center justify-between bg-base-100 px-4">
+        <label for={field} class={labelClass}>
+          {$_(`candidateApp.basicInfo.fields.${field}`)}
+        </label>
         <input
-          type="number"
+          type="text"
           id={field}
-          placeholder="0"
-          class="input input-ghost input-sm w-6/12 text-right" />
-      {:else}
-        <select id={field} class="select select-bordered select-sm w-6/12">
-          <option value="">{$_(`candidateApp.basicInfo.fields.${field}`)}</option>
-          {#each fieldOptions.get(field) ?? [] as option}
-            <option value={option}>{option}</option>
-          {/each}
-        </select>
-      {/if}
-    </div>
-  </FieldGroup>
+          placeholder="PLACEHOLDER"
+          class="input-ghost input input-sm w-6/12 text-right" />
+      </div>
+      <p class={disclaimerClass} slot="footer">
+        {$_('candidateApp.basicInfo.disclaimer')}
+      </p>
+    </FieldGroup>
 
-  <FieldGroup let:field customStyle="height: 60px">
-    <div class="flex h-full items-center justify-between px-4">
-      <span class={labelClass}>
-        {$_('candidateApp.basicInfo.fields.portrait')}
-      </span>
-      <label for="portrait" class="mr-20 cursor-pointer text-indigo-700"
-        >{$_('candidateApp.basicInfo.tapToAddPhoto')}</label>
-      <input type="file" id="portrait" placeholder="PLACEHOLDER" class="hidden" />
-    </div>
-  </FieldGroup>
+    <FieldGroup fields={editableFields} let:field>
+      <div class="flex items-center justify-between bg-base-100 px-4">
+        <label for={field} class={labelClass}>
+          {$_(`candidateApp.basicInfo.fields.${field}`)}
+        </label>
+        {#if field === 'age'}
+          <input
+            type="number"
+            id={field}
+            placeholder="0"
+            class="input-ghost input input-sm w-6/12 text-right" />
+        {:else}
+          <select id={field} class="select select-sm w-6/12 text-primary">
+            <option disabled selected value style="display: none;" />
+            {#each fieldOptions.get(field) ?? [] as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        {/if}
+      </div>
+    </FieldGroup>
 
-  <FieldGroup let:field>
-    <div class="flex items-center justify-between px-4">
-      <label for="portrait" class={labelClass}>
-        {$_('candidateApp.basicInfo.fields.unaffiliated')}
-      </label>
-      <input type="checkbox" class="toggle toggle-primary mr-8" checked />
-    </div>
-    <p class={disclaimerClass} slot="footer">
-      {$_('candidateApp.basicInfo.unaffiliatedDescription')}
-    </p>
-  </FieldGroup>
-  <FieldGroup>
-    <p class={disclaimerClass} slot="header">
-      {$_('candidateApp.basicInfo.electionManifesto')}
-    </p>
-    <textarea id="message" rows="4" class="w-full resize-none bg-base-300 p-6 !outline-none" />
-  </FieldGroup>
+    <FieldGroup let:field customStyle="height: 60px">
+      <div class="flex h-full items-center justify-between bg-base-100 px-4">
+        <span class={labelClass}>
+          {$_('candidateApp.basicInfo.fields.portrait')}
+        </span>
+        <label for="portrait" class="mr-20 cursor-pointer text-primary"
+          >{$_('candidateApp.basicInfo.tapToAddPhoto')}</label>
+        <input type="file" id="portrait" placeholder="PLACEHOLDER" class="hidden" />
+      </div>
+    </FieldGroup>
+
+    <FieldGroup let:field>
+      <div class="flex items-center justify-between bg-base-100 px-4">
+        <label for="unaffiliated" class={labelClass}>
+          {$_('candidateApp.basicInfo.fields.unaffiliated')}
+        </label>
+        <input id="unaffiliated" type="checkbox" class="toggle-primary toggle mr-8" checked />
+      </div>
+      <p class={disclaimerClass} slot="footer">
+        {$_('candidateApp.basicInfo.unaffiliatedDescription')}
+      </p>
+    </FieldGroup>
+    <FieldGroup>
+      <label for="message" class={disclaimerClass} slot="header"
+        >{$_('candidateApp.basicInfo.electionManifesto')}</label>
+      <!-- <p class={disclaimerClass} slot="header">
+        {$_('candidateApp.basicInfo.electionManifesto')}
+      </p> -->
+      <textarea id="message" rows="4" class="w-full resize-none bg-base-100 p-6 !outline-none" />
+    </FieldGroup>
+  </div>
 </div>


### PR DESCRIPTION
## WHY:

Matches the basic information UI with Figma. Does not implement lock icons or button yet due to the icons being only present in the `main` branch.

### What has been changed (if possible, add screenshots, gifs, etc. )

Basic information UI has changed.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
