### PR TITLE
Registration backend

### DIFF
--- a/backend/vaa-strapi/src/api/candidate/content-types/candidate/schema.json
+++ b/backend/vaa-strapi/src/api/candidate/content-types/candidate/schema.json
@@ -83,6 +83,27 @@
       "relation": "oneToMany",
       "target": "api::nomination.nomination",
       "mappedBy": "candidate"
+    },
+    "email": {
+      "type": "string",
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "registrationKey": {
+      "type": "string",
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "user": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "plugin::users-permissions.user",
+      "inversedBy": "candidate",
+      "configurable": false,
+      "private": true,
+      "searchable": false
     }
   }
 }

--- a/backend/vaa-strapi/src/extensions/users-permissions/content-types/user/schema.json
+++ b/backend/vaa-strapi/src/extensions/users-permissions/content-types/user/schema.json
@@ -36,6 +36,12 @@
       "private": true,
       "searchable": false
     },
+    "registrationKey": {
+      "type": "string",
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
     "resetPasswordToken": {
       "type": "string",
       "configurable": false,

--- a/backend/vaa-strapi/src/extensions/users-permissions/content-types/user/schema.json
+++ b/backend/vaa-strapi/src/extensions/users-permissions/content-types/user/schema.json
@@ -36,12 +36,6 @@
       "private": true,
       "searchable": false
     },
-    "registrationKey": {
-      "type": "string",
-      "configurable": false,
-      "private": true,
-      "searchable": false
-    },
     "resetPasswordToken": {
       "type": "string",
       "configurable": false,
@@ -75,7 +69,10 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::candidate.candidate",
-      "configurable": false
+      "mappedBy": "user",
+      "configurable": false,
+      "private": true,
+      "searchable": false
     }
   },
   "config": {

--- a/backend/vaa-strapi/src/extensions/users-permissions/controllers/candidate.ts
+++ b/backend/vaa-strapi/src/extensions/users-permissions/controllers/candidate.ts
@@ -1,0 +1,57 @@
+'use strict';
+
+const { yup, validateYupSchema, sanitize, errors: { ValidationError } } = require('@strapi/utils');
+
+const checkSchema = yup.object({
+  registrationKey: yup.string().required(),
+});
+const validateCheckBody = validateYupSchema(checkSchema);
+
+const registerSchema = yup.object({
+  registrationKey: yup.string().required(),
+  password: yup.string().required(),
+});
+const validateRegisterBody = validateYupSchema(registerSchema);
+
+const sanitizeCandidate = (candidate, ctx) => {
+  const { auth } = ctx.state;
+  const candidateSchema = strapi.getModel('api::candidate.candidate');
+
+  return sanitize.contentAPI.output(candidate, candidateSchema, { auth });
+};
+
+module.exports = {
+  async check(ctx) {
+    const params = ctx.request.body;
+    await validateCheckBody(params);
+
+    const user = await strapi.query('plugin::users-permissions.user').findOne({
+      where: { registrationKey: params.registrationKey },
+      populate: ['candidate'],
+    });
+
+    if (!user || !user.candidate) {
+      throw new ValidationError('Incorrect registration key');
+    }
+
+    return {
+      candidate: await sanitizeCandidate(user.candidate, ctx),
+    };
+  },
+  async register(ctx) {
+    const params = ctx.request.body;
+    await validateRegisterBody(params);
+
+    const user = await strapi.query('plugin::users-permissions.user').findOne({
+      where: { registrationKey: params.registrationKey },
+      populate: ['candidate'],
+    });
+
+    if (!user || !user.candidate) {
+      throw new ValidationError('Incorrect registration key');
+    }
+
+    // TODO: validate password requirements
+    // TODO: set the user password
+  },
+};

--- a/backend/vaa-strapi/src/extensions/users-permissions/controllers/candidate.ts
+++ b/backend/vaa-strapi/src/extensions/users-permissions/controllers/candidate.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-const { yup, validateYupSchema, sanitize, errors: { ValidationError } } = require('@strapi/utils');
+const { yup, validateYupSchema, sanitize, errors: { ValidationError, ApplicationError } } = require('@strapi/utils');
 
 const checkSchema = yup.object({
   registrationKey: yup.string().required(),
@@ -25,33 +25,71 @@ module.exports = {
     const params = ctx.request.body;
     await validateCheckBody(params);
 
-    const user = await strapi.query('plugin::users-permissions.user').findOne({
+    const candidate = await strapi.query('api::candidate.candidate').findOne({
+      populate: ['user'],
       where: { registrationKey: params.registrationKey },
-      populate: ['candidate'],
     });
 
-    if (!user || !user.candidate) {
+    if (!candidate) {
       throw new ValidationError('Incorrect registration key');
     }
 
+    if (candidate.user) {
+      throw new ValidationError('The user associated with the registration key is already registered.');
+    }
+
     return {
-      candidate: await sanitizeCandidate(user.candidate, ctx),
+      candidate: await sanitizeCandidate(candidate, ctx),
     };
   },
   async register(ctx) {
     const params = ctx.request.body;
     await validateRegisterBody(params);
+    // TODO: validate password requirements
 
-    const user = await strapi.query('plugin::users-permissions.user').findOne({
+    const candidate = await strapi.query('api::candidate.candidate').findOne({
+      populate: ['user'],
       where: { registrationKey: params.registrationKey },
-      populate: ['candidate'],
     });
 
-    if (!user || !user.candidate) {
+    if (!candidate) {
       throw new ValidationError('Incorrect registration key');
     }
 
-    // TODO: validate password requirements
-    // TODO: set the user password
+    if (candidate.user) {
+      throw new ValidationError('The user associated with the registration key is already registered.');
+    }
+
+    const pluginStore = await strapi.store({ type: 'plugin', name: 'users-permissions' });
+    const settings = await pluginStore.get({ key: 'advanced' });
+    const role = await strapi
+      .query('plugin::users-permissions.role')
+      .findOne({ where: { type: settings.default_role } });
+
+    if (!role) {
+      throw new ApplicationError('Impossible to find the default role');
+    }
+
+    const user = await strapi.plugin('users-permissions').service('user').add({
+      role: role.id,
+      username: candidate.email,
+      email: candidate.email,
+      password: params.password,
+      confirmed: true,
+    });
+
+    // TODO: this could be improved, specifically, there exists candidate per locale,
+    // so we have to update based on email (unique) compared to relying on the ID
+    await strapi.query('api::candidate.candidate').update({
+      where: { email: candidate.email },
+      data: {
+        registrationKey: null,
+        user: user.id,
+      },
+    });
+
+    return {
+      success: true,
+    };
   },
 };

--- a/backend/vaa-strapi/src/extensions/users-permissions/controllers/candidate.ts
+++ b/backend/vaa-strapi/src/extensions/users-permissions/controllers/candidate.ts
@@ -1,23 +1,28 @@
 'use strict';
 
-const { yup, validateYupSchema, sanitize, errors: { ValidationError, ApplicationError } } = require('@strapi/utils');
+const {
+  yup,
+  validateYupSchema,
+  sanitize,
+  errors: {ValidationError, ApplicationError}
+} = require('@strapi/utils');
 
 const checkSchema = yup.object({
-  registrationKey: yup.string().required(),
+  registrationKey: yup.string().required()
 });
 const validateCheckBody = validateYupSchema(checkSchema);
 
 const registerSchema = yup.object({
   registrationKey: yup.string().required(),
-  password: yup.string().required(),
+  password: yup.string().required()
 });
 const validateRegisterBody = validateYupSchema(registerSchema);
 
 const sanitizeCandidate = (candidate, ctx) => {
-  const { auth } = ctx.state;
+  const {auth} = ctx.state;
   const candidateSchema = strapi.getModel('api::candidate.candidate');
 
-  return sanitize.contentAPI.output(candidate, candidateSchema, { auth });
+  return sanitize.contentAPI.output(candidate, candidateSchema, {auth});
 };
 
 module.exports = {
@@ -27,7 +32,7 @@ module.exports = {
 
     const candidate = await strapi.query('api::candidate.candidate').findOne({
       populate: ['user'],
-      where: { registrationKey: params.registrationKey },
+      where: {registrationKey: params.registrationKey}
     });
 
     if (!candidate) {
@@ -35,11 +40,13 @@ module.exports = {
     }
 
     if (candidate.user) {
-      throw new ValidationError('The user associated with the registration key is already registered.');
+      throw new ValidationError(
+        'The user associated with the registration key is already registered.'
+      );
     }
 
     return {
-      candidate: await sanitizeCandidate(candidate, ctx),
+      candidate: await sanitizeCandidate(candidate, ctx)
     };
   },
   async register(ctx) {
@@ -49,7 +56,7 @@ module.exports = {
 
     const candidate = await strapi.query('api::candidate.candidate').findOne({
       populate: ['user'],
-      where: { registrationKey: params.registrationKey },
+      where: {registrationKey: params.registrationKey}
     });
 
     if (!candidate) {
@@ -57,14 +64,16 @@ module.exports = {
     }
 
     if (candidate.user) {
-      throw new ValidationError('The user associated with the registration key is already registered.');
+      throw new ValidationError(
+        'The user associated with the registration key is already registered.'
+      );
     }
 
-    const pluginStore = await strapi.store({ type: 'plugin', name: 'users-permissions' });
-    const settings = await pluginStore.get({ key: 'advanced' });
+    const pluginStore = await strapi.store({type: 'plugin', name: 'users-permissions'});
+    const settings = await pluginStore.get({key: 'advanced'});
     const role = await strapi
       .query('plugin::users-permissions.role')
-      .findOne({ where: { type: settings.default_role } });
+      .findOne({where: {type: settings.default_role}});
 
     if (!role) {
       throw new ApplicationError('Impossible to find the default role');
@@ -75,21 +84,21 @@ module.exports = {
       username: candidate.email,
       email: candidate.email,
       password: params.password,
-      confirmed: true,
+      confirmed: true
     });
 
     // TODO: this could be improved, specifically, there exists candidate per locale,
     // so we have to update based on email (unique) compared to relying on the ID
     await strapi.query('api::candidate.candidate').update({
-      where: { email: candidate.email },
+      where: {email: candidate.email},
       data: {
         registrationKey: null,
-        user: user.id,
-      },
+        user: user.id
+      }
     });
 
     return {
-      success: true,
+      success: true
     };
-  },
+  }
 };

--- a/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
+++ b/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
@@ -1,8 +1,12 @@
 'use strict';
 
-const defaultAuthenticatedPermissions = [
-  'api::candidate.candidate.findOne',
-  'api::candidate.candidate.find'
+import candidate from './controllers/candidate';
+
+const defaultPermissions = [
+  { action: 'plugin::users-permissions.candidate.check', roleType: 'public' },
+  { action: 'plugin::users-permissions.candidate.register', roleType: 'public' },
+  { action: 'api::candidate.candidate.findOne', roleType: 'authenticated' },
+  { action: 'api::candidate.candidate.find', roleType: 'authenticated' },
 ];
 
 module.exports = async (plugin) => {
@@ -17,32 +21,57 @@ module.exports = async (plugin) => {
     advanced.allow_register = false;
     await pluginStore.set({key: 'advanced', value: advanced});
 
-    // Setup default permissions for authenticated role
-    const authenticated = await strapi.query('plugin::users-permissions.role').findOne({
-      where: {
-        type: 'authenticated'
+    // Setup default permissions
+    for (const permission of defaultPermissions) {
+      const role = await strapi.query('plugin::users-permissions.role').findOne({
+        where: {
+          type: permission.roleType,
+        },
+      });
+      if (!role) {
+        console.error(`Failed to initialize default permissions due to missing role type: ${permission.roleType}`);
+        continue;
       }
-    });
 
-    for (const permission of defaultAuthenticatedPermissions) {
       const count = await strapi.query('plugin::users-permissions.permission').count({
         where: {
-          action: permission,
-          role: authenticated.id
+          action: permission.action,
+          role: role.id
         }
       });
       if (count !== 0) continue;
 
       await strapi.query('plugin::users-permissions.permission').create({
         data: {
-          action: permission,
-          role: authenticated.id
+          action: permission.action,
+          role: role.id
         }
       });
     }
 
     return res;
   };
+
+  // Implement candidate registration functionality
+  plugin.controllers.candidate = candidate;
+  plugin.routes['content-api'].routes.push({
+    method: 'POST',
+    path: '/auth/candidate/check',
+    handler: 'candidate.check',
+    config : {
+      middlewares: ['plugin::users-permissions.rateLimit'],
+      prefix: '',
+    },
+  })
+  plugin.routes['content-api'].routes.push({
+    method: 'POST',
+    path: '/auth/candidate/register',
+    handler: 'candidate.register',
+    config : {
+      middlewares: ['plugin::users-permissions.rateLimit'],
+      prefix: '',
+    },
+  })
 
   return plugin;
 };

--- a/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
+++ b/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
@@ -12,7 +12,7 @@ const defaultPermissions = [
 module.exports = async (plugin) => {
   const origBootstrap = plugin.bootstrap;
   plugin.bootstrap = async (ctx) => {
-    const res = origBootstrap(ctx);
+    const res = await origBootstrap(ctx);
 
     const pluginStore = strapi.store({type: 'plugin', name: 'users-permissions'});
 

--- a/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
+++ b/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
@@ -3,10 +3,10 @@
 import candidate from './controllers/candidate';
 
 const defaultPermissions = [
-  { action: 'plugin::users-permissions.candidate.check', roleType: 'public' },
-  { action: 'plugin::users-permissions.candidate.register', roleType: 'public' },
-  { action: 'api::candidate.candidate.findOne', roleType: 'authenticated' },
-  { action: 'api::candidate.candidate.find', roleType: 'authenticated' },
+  {action: 'plugin::users-permissions.candidate.check', roleType: 'public'},
+  {action: 'plugin::users-permissions.candidate.register', roleType: 'public'},
+  {action: 'api::candidate.candidate.findOne', roleType: 'authenticated'},
+  {action: 'api::candidate.candidate.find', roleType: 'authenticated'}
 ];
 
 module.exports = async (plugin) => {
@@ -25,11 +25,13 @@ module.exports = async (plugin) => {
     for (const permission of defaultPermissions) {
       const role = await strapi.query('plugin::users-permissions.role').findOne({
         where: {
-          type: permission.roleType,
-        },
+          type: permission.roleType
+        }
       });
       if (!role) {
-        console.error(`Failed to initialize default permissions due to missing role type: ${permission.roleType}`);
+        console.error(
+          `Failed to initialize default permissions due to missing role type: ${permission.roleType}`
+        );
         continue;
       }
 
@@ -58,20 +60,20 @@ module.exports = async (plugin) => {
     method: 'POST',
     path: '/auth/candidate/check',
     handler: 'candidate.check',
-    config : {
+    config: {
       middlewares: ['plugin::users-permissions.rateLimit'],
-      prefix: '',
-    },
-  })
+      prefix: ''
+    }
+  });
   plugin.routes['content-api'].routes.push({
     method: 'POST',
     path: '/auth/candidate/register',
     handler: 'candidate.register',
-    config : {
+    config: {
       middlewares: ['plugin::users-permissions.rateLimit'],
-      prefix: '',
-    },
-  })
+      prefix: ''
+    }
+  });
 
   return plugin;
 };

--- a/backend/vaa-strapi/src/functions/generateMockData.ts
+++ b/backend/vaa-strapi/src/functions/generateMockData.ts
@@ -1363,8 +1363,8 @@ async function createCandidateUsers() {
   await strapi.query(USER_API).update({
     where: {id: candidate.id},
     data: {
-      registrationKey: null,
-    },
+      registrationKey: null
+    }
   });
 }
 

--- a/backend/vaa-strapi/src/functions/generateMockData.ts
+++ b/backend/vaa-strapi/src/functions/generateMockData.ts
@@ -205,6 +205,10 @@ export async function generateMockData() {
   await createPartyAnswers();
   console.info('Done!');
   console.info('#######################################');
+  console.info('inserting candidate users');
+  await createCandidateUsers();
+  console.info('Done!');
+  console.info('#######################################');
 }
 
 /**
@@ -1332,6 +1336,36 @@ async function createPartyAnswers() {
       ]);
     }
   }
+}
+
+async function createCandidateUsers() {
+  const authenticated = await strapi.query('plugin::users-permissions.role').findOne({
+    where: {
+      type: 'authenticated'
+    }
+  });
+  const candidate = await strapi.entityService.findOne(CANDIDATE_API, {});
+
+  await strapi.entityService.create(USER_API, {
+    data: {
+      username: 'first.last',
+      email: 'first.last@example.com',
+      password: 'password',
+      provider: 'local',
+      confirmed: true,
+      blocked: false,
+      role: authenticated.id,
+      candidate: candidate.id
+    }
+  });
+
+  // Disable registration key for the candidate we chose as they're already registered
+  await strapi.query(USER_API).update({
+    where: {id: candidate.id},
+    data: {
+      registrationKey: null,
+    },
+  });
 }
 
 function capitaliseFirstLetter(word: string) {

--- a/backend/vaa-strapi/src/functions/generateMockData.ts
+++ b/backend/vaa-strapi/src/functions/generateMockData.ts
@@ -10,6 +10,7 @@
  * and also it is not possible to create localizations using the bulk insert.
  */
 
+import crypto from 'crypto';
 import {faker, fakerES, fakerFI} from '@faker-js/faker';
 import {generateMockDataOnInitialise, generateMockDataOnRestart} from '../constants';
 import mockQuestions from './mockQuestions.json';
@@ -202,10 +203,6 @@ export async function generateMockData() {
   console.info('#######################################');
   console.info('inserting party answers');
   await createPartyAnswers();
-  console.info('Done!');
-  console.info('#######################################');
-  console.info('inserting candidate users');
-  await createCandidateUsers();
   console.info('Done!');
   console.info('#######################################');
 }
@@ -570,6 +567,8 @@ async function createCandidates(length: number) {
     const candidateMainLocale = await strapi.entityService.create(CANDIDATE_API, {
       data: {
         ...candidateObj,
+        email: faker.internet.exampleEmail(),
+        registrationKey: crypto.randomUUID(),
         locale: mainLocale.code,
         publishedAt: new Date()
       }
@@ -1333,28 +1332,6 @@ async function createPartyAnswers() {
       ]);
     }
   }
-}
-
-async function createCandidateUsers() {
-  const authenticated = await strapi.query('plugin::users-permissions.role').findOne({
-    where: {
-      type: 'authenticated'
-    }
-  });
-  const candidate = await strapi.entityService.findOne(CANDIDATE_API, {});
-
-  await strapi.entityService.create(USER_API, {
-    data: {
-      username: 'asd',
-      email: 'asd@asd.asd',
-      password: 'asdasd',
-      provider: 'local',
-      confirmed: true,
-      blocked: false,
-      role: authenticated.id,
-      candidate: candidate.id
-    }
-  });
 }
 
 function capitaliseFirstLetter(word: string) {

--- a/docs/admin-guide/candidate-app.md
+++ b/docs/admin-guide/candidate-app.md
@@ -1,0 +1,27 @@
+# Candidate App
+
+## Mock Data
+By default, mock data includes the user `first.last@example.com` with the password `password` that can be used to test the candidate app.
+
+## Creating a New Candidate
+A candidate can log in to the candidate app either by having the admin give them a registration key or registering an account for them.
+
+### Using Registration Key
+To use the registration code, you need to navigate to the Strapi's admin area (http://localhost:1337), select the "Content Manager" tab, and choose the "Candidates" tab from the dropdown. If a candidate you want to log in as doesn't exist yet, you can use the "Create new entry" button to create one.
+
+Afterward, edit the desired candidate and choose a secure and random value for the registrationKey field. Then, save the change by clicking the "Save" button. The chosen registrationKey should be shared, and then the candidate can navigate to http://localhost:5173/candidate/register to create their account.
+
+### Manually
+To create the user manually, you need to navigate to the Strapi's admin area (http://localhost:1337), select the "Content Manager" tab, and choose the "User" tab from the dropdown. 
+
+You can create a new user using the "Create new entry" button. The following fields should be set:
+- username (any desired username)
+- email (any desired email, it'll be used for logging in)
+- password (any strong password)
+- confirmed => True
+- blocked => False
+- role => Authenticated
+- candidate => the desired candidate the user is linked to
+
+Then, use the "Save" button and you should be able to log in as the candidate at http://localhost:5173/candidate.
+

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,7 +1,7 @@
 // hooks.server.ts
 import type {Handle} from '@sveltejs/kit';
 import type {HandleServerError} from '@sveltejs/kit';
-import {locale, _} from 'svelte-i18n';
+import {locale} from 'svelte-i18n';
 
 export const handle: Handle = (async ({event, resolve}) => {
   const lang = event.request.headers.get('accept-language')?.split(',')[0];

--- a/frontend/src/lib/components/authentication/AuthenticationProvider.svelte
+++ b/frontend/src/lib/components/authentication/AuthenticationProvider.svelte
@@ -17,7 +17,7 @@
   <slot />
 {:else if $token === undefined || ($token && !$user)}
   <div class="mt-100 flex h-screen flex-col items-center">
-    <span class="loading loading-spinner loading-lg" />
+    <span class="loading-spinner loading-lg loading" />
   </div>
 {:else}
   <LoginPage />

--- a/frontend/src/lib/components/authentication/LoginPage.svelte
+++ b/frontend/src/lib/components/authentication/LoginPage.svelte
@@ -60,11 +60,11 @@
           {#if wrongCredentials}
             <p class="text-center text-error">{$_('candidate.wrong_email_or_password')}</p>
           {/if}
-          <button type="submit" class="btn btn-primary mb-md w-full max-w-md"
+          <button type="submit" class="btn-primary btn mb-md w-full max-w-md"
             >{$_('candidate.sign_in')}</button>
-          <a href="/help" class="btn btn-ghost w-full max-w-md"
+          <a href="/help" class="btn-ghost btn w-full max-w-md"
             >{$_('candidate.contact_support')}</a>
-          <a href="/" class="btn btn-ghost w-full max-w-md"
+          <a href="/" class="btn-ghost btn w-full max-w-md"
             >{$_('candidate.election_compass_for_voters')}</a>
         </form>
       </div>

--- a/frontend/src/lib/components/candidates/CandidateOpinions.svelte
+++ b/frontend/src/lib/components/candidates/CandidateOpinions.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import {page} from '$app/stores';
-
   export let candidate: CandidateProps;
 </script>
 

--- a/frontend/src/lib/components/common/FieldGroup.svelte
+++ b/frontend/src/lib/components/common/FieldGroup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export let fields: any[] = ['default'];
+  export let fields: string[] = ['default'];
   export let customStyle: string | undefined = undefined;
 </script>
 

--- a/frontend/src/lib/components/entityCard/EntityCard.svelte
+++ b/frontend/src/lib/components/entityCard/EntityCard.svelte
@@ -37,7 +37,7 @@
       {#if imgSrc}
         <img class="rounded-sm" src={imgSrc} alt={imgAlt} width={imgWidth} height={imgHeight} />
       {:else}
-        <div class="avatar placeholder">
+        <div class="placeholder avatar">
           <div class="w-[3.125rem] rounded-full bg-base-300">
             <span class="text-2xl">{title.charAt(0)}</span>
           </div>

--- a/frontend/src/lib/components/navigation/Navigation.svelte
+++ b/frontend/src/lib/components/navigation/Navigation.svelte
@@ -60,10 +60,10 @@
         seconds.
       </p>
       <br />
-      <button class="btn-glass btn btn-primary w-full" on:click={closeModal}
+      <button class="btn-glass btn-primary btn w-full" on:click={closeModal}
         >{$_('candidateApp.navbar.continueEnteringData')}</button>
       <div class="h-4" />
-      <button class="btn btn-error btn-outline w-full" on:click={logout}
+      <button class="btn-outline btn-error btn w-full" on:click={logout}
         >{$_('candidateApp.navbar.logOut')}</button>
     </div>
   </TimedModal>
@@ -72,7 +72,7 @@
     <!-- Navbar -->
     <div class="navbar w-full bg-base-300">
       <div class="flex-none">
-        <button aria-label="open sidebar" class="btn btn-square btn-ghost" on:click={handleClick}>
+        <button aria-label="open sidebar" class="btn-ghost btn-square btn" on:click={handleClick}>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -84,7 +84,7 @@
       <div class="mx-2 flex-1 px-2">PubLogo</div>
       <div class="flex-none">
         {#if $user}
-          <button class="btn btn-ghost btn-lg" on:click={triggerLogout}
+          <button class="btn-ghost btn-lg btn" on:click={triggerLogout}
             >{$_('candidateApp.navbar.logOut')}</button>
         {/if}
       </div>
@@ -96,7 +96,7 @@
     <label for="sidebar" aria-label="close sidebar" class="drawer-overlay" />
     <ul class="menu h-full w-fit bg-base-200 p-4">
       <!-- Sidebar content here -->
-      <button aria-label="close sidebar" class="btn btn-square btn-ghost" on:click={handleClick}>
+      <button aria-label="close sidebar" class="btn-ghost btn-square btn" on:click={handleClick}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           class="h-24 w-24"

--- a/frontend/src/lib/components/navigation/TimedModal.svelte
+++ b/frontend/src/lib/components/navigation/TimedModal.svelte
@@ -1,6 +1,5 @@
 <!-- TimedModal.svelte -->
 <script lang="ts">
-  import {_} from 'svelte-i18n';
   import {tweened} from 'svelte/motion';
   import {onDestroy, onMount} from 'svelte';
 

--- a/frontend/src/lib/components/questions/LikertScaleAnsweringButtons.svelte
+++ b/frontend/src/lib/components/questions/LikertScaleAnsweringButtons.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {createEventDispatcher} from 'svelte';
-  import {_} from 'svelte-i18n';
 
   export let name: QuestionProps['id'];
   export let options: QuestionProps['options'];

--- a/frontend/src/lib/components/questions/Question.svelte
+++ b/frontend/src/lib/components/questions/Question.svelte
@@ -39,7 +39,7 @@
   {#if info && info !== ''}
     <div class="flex items-center justify-center">
       <!-- TODO: Convert to Expander component -->
-      <button class="btn btn-ghost">{$_('questions.readMore')}</button>
+      <button class="btn-ghost btn">{$_('questions.readMore')}</button>
     </div>
   {/if}
   <div class="flex flex-col items-center justify-center gap-md pt-lg">
@@ -50,7 +50,7 @@
     {/if}
     <div>
       <!-- TODO: Add action and an icon -->
-      <button on:click={onSkip} class="btn btn-ghost text-secondary">{$_('questions.skip')}</button>
+      <button on:click={onSkip} class="btn-ghost btn text-secondary">{$_('questions.skip')}</button>
     </div>
   </div>
 </fieldset>

--- a/frontend/src/lib/components/scoreGauge/ScoreGauge.svelte
+++ b/frontend/src/lib/components/scoreGauge/ScoreGauge.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type {ScoreGaugeProps} from './ScoreGauge.type';
   import {getUUID} from '$lib/utils/components';
-  import {_} from 'svelte-i18n';
 
   type $$Props = ScoreGaugeProps;
 

--- a/frontend/src/lib/components/shared/Tabs.svelte
+++ b/frontend/src/lib/components/shared/Tabs.svelte
@@ -9,7 +9,7 @@
 <ul class="flex items-center justify-center bg-base-300 px-lg py-8">
   {#each tabs as tab}
     <li
-      class="btn btn-outline m-0 h-[2.2rem] min-h-[2.2rem] w-auto flex-grow truncate rounded-sm px-12 text-md text-secondary hover:bg-base-100 hover:text-primary focus:bg-base-100 focus:text-primary"
+      class="btn-outline btn m-0 h-[2.2rem] min-h-[2.2rem] w-auto flex-grow truncate rounded-sm px-12 text-md text-secondary hover:bg-base-100 hover:text-primary focus:bg-base-100 focus:text-primary"
       tabindex="0"
       role="tab"
       on:click={() => dispatch('changeTab', tab)}

--- a/frontend/src/lib/voter/vaa-matching/tests/algorithms.test.ts
+++ b/frontend/src/lib/voter/vaa-matching/tests/algorithms.test.ts
@@ -274,6 +274,7 @@ describe('matchingAlgorithm', () => {
     const likertScale = 5;
     const values = [0, 0.5, 1];
     const coords = values.map((v) => v * maxDist - maxVal);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {questions, voter, candidates, algorithm, matches} = createMatchesAndEntities(
       createLikertScaleValues(likertScale, values),
       [createLikertScaleValues(likertScale, values)],
@@ -295,6 +296,7 @@ describe('matchingAlgorithm', () => {
     const valuesMissing: MatchableValue[] = [MISSING_VALUE, MISSING_VALUE, MISSING_VALUE];
     test('MissingValueDistanceMethod.Neutral', () => {
       const dist = (maxDist * (0.25 + 0 + 0.5)) / 3;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const {questions, voter, candidates, algorithm, matches} = createMatchesAndEntities(
         createLikertScaleValues(likertScale, values),
         [valuesMissing],
@@ -306,6 +308,7 @@ describe('matchingAlgorithm', () => {
     });
     test('MissingValueDistanceMethod.Neutral', () => {
       const dist = (maxDist * (0.75 + 0.5 + 1)) / 3;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const {questions, voter, candidates, algorithm, matches} = createMatchesAndEntities(
         createLikertScaleValues(likertScale, values),
         [valuesMissing],
@@ -317,6 +320,7 @@ describe('matchingAlgorithm', () => {
     });
     test('MissingValueDistanceMethod.AbsoluteMaximum', () => {
       const dist = maxDist;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const {questions, voter, candidates, algorithm, matches} = createMatchesAndEntities(
         createLikertScaleValues(likertScale, values),
         [valuesMissing],
@@ -333,6 +337,7 @@ describe('matchingAlgorithm', () => {
       const voterValues = [0.5, 1, 0];
       const candValues = [0, 0.5, 1];
       const dist = (maxDist * (0.5 + 0.5 + 1)) / 3;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const {questions, voter, candidates, algorithm, matches} = createMatchesAndEntities(
         createLikertScaleValues(likertScale, voterValues),
         [createLikertScaleValues(likertScale, candValues)],
@@ -352,6 +357,7 @@ describe('matchingAlgorithm', () => {
       factors = factors.map((v) => ((1 - v) / 2) * maxDist);
       // Add up and divide by dims
       const dist = factors.reduce((a, b) => a + b, 0) / 3;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const {questions, voter, candidates, algorithm, matches} = createMatchesAndEntities(
         createLikertScaleValues(likertScale, voterValues),
         [createLikertScaleValues(likertScale, candValues)],
@@ -391,6 +397,7 @@ describe('matchingAlgorithm', () => {
       const likertScale = 5;
       const voterValues = [0, 0, 0, 0, 0.5];
       const candValues = [0, 0, 1, 1, 1];
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const {questions, voter, candidates, algorithm} = createMatchesAndEntities(
         createLikertScaleValues(likertScale, voterValues),
         [createLikertScaleValues(likertScale, candValues)],

--- a/frontend/src/routes/(voters)/navigation/+page.svelte
+++ b/frontend/src/routes/(voters)/navigation/+page.svelte
@@ -6,7 +6,7 @@
         <h2 class="card-title">Questions</h2>
         <p>Answer questions to find suggestions about your candidates.</p>
         <div class="card-actions justify-end">
-          <a href="/questions" class="btn btn-primary w-full max-w-md">Answer Questions</a>
+          <a href="/questions" class="btn-primary btn w-full max-w-md">Answer Questions</a>
         </div>
       </div>
     </div>
@@ -15,7 +15,7 @@
         <h2 class="card-title">Candidates</h2>
         <p>View the list of candidates.</p>
         <div class="card-actions justify-end">
-          <a href="/candidates" class="btn btn-primary w-full max-w-md">View Candidates</a>
+          <a href="/candidates" class="btn-primary btn w-full max-w-md">View Candidates</a>
         </div>
       </div>
     </div>
@@ -24,7 +24,7 @@
         <h2 class="card-title">Parties</h2>
         <p>View the list of parties.</p>
         <div class="card-actions justify-end">
-          <a href="/parties" class="btn btn-primary w-full max-w-md">View Parties</a>
+          <a href="/parties" class="btn-primary btn w-full max-w-md">View Parties</a>
         </div>
       </div>
     </div>

--- a/frontend/src/routes/(voters)/questions/+page.svelte
+++ b/frontend/src/routes/(voters)/questions/+page.svelte
@@ -18,7 +18,7 @@
     {$page.data.appLabels.viewTexts.yourOpinionsTitle}
   </h1>
   <p class="text-center">{opinionsDescriptionText}</p>
-  <a href={firstQuestionUrl} class="btn btn-primary"
+  <a href={firstQuestionUrl} class="btn-primary btn"
     >{$page.data.appLabels.actionLabels.startQuestions}</a>
 </div>
 <div class="mb-60 p-lg text-center text-sm text-secondary">

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {locale} from 'svelte-i18n';
-  import {goto} from '$app/navigation';
   import {page} from '$app/stores';
   import {resetLocalStorage} from '$lib/utils/stores';
 
@@ -42,11 +41,11 @@
         <a
           href="/navigation"
           on:click={resetLocalStorage}
-          class="btn btn-primary mb-md w-full max-w-md"
+          class="btn-primary btn mb-md w-full max-w-md"
           >{$page.data.appLabels.actionLabels.startButton}</a>
-        <a href="/information" class="btn btn-ghost w-full max-w-md"
+        <a href="/information" class="btn-ghost btn w-full max-w-md"
           >{$page.data.appLabels.actionLabels.electionInfo}</a>
-        <a href="/about" class="btn btn-ghost w-full max-w-md"
+        <a href="/about" class="btn-ghost btn w-full max-w-md"
           >{$page.data.appLabels.actionLabels.howItWorks}</a>
       </div>
     </div>

--- a/frontend/src/routes/candidate/profile/+page.svelte
+++ b/frontend/src/routes/candidate/profile/+page.svelte
@@ -34,7 +34,7 @@
         type="text"
         id={field}
         placeholder="PLACEHOLDER"
-        class="input input-ghost input-sm w-6/12 text-right" />
+        class="input-ghost input input-sm w-6/12 text-right" />
     </div>
     <p class={disclaimerClass} slot="footer">
       {$_('candidateApp.basicInfo.disclaimer')}
@@ -51,9 +51,9 @@
           type="number"
           id={field}
           placeholder="0"
-          class="input input-ghost input-sm w-6/12 text-right" />
+          class="input-ghost input input-sm w-6/12 text-right" />
       {:else}
-        <select id={field} class="select select-bordered select-sm w-6/12">
+        <select id={field} class="select-bordered select select-sm w-6/12">
           <option value="">{$_(`candidateApp.basicInfo.fields.${field}`)}</option>
           {#each fieldOptions.get(field) ?? [] as option}
             <option value={option}>{option}</option>
@@ -79,7 +79,7 @@
       <label for="portrait" class={labelClass}>
         {$_('candidateApp.basicInfo.fields.unaffiliated')}
       </label>
-      <input type="checkbox" class="toggle toggle-primary mr-8" checked />
+      <input type="checkbox" class="toggle-primary toggle mr-8" checked />
     </div>
     <p class={disclaimerClass} slot="footer">
       {$_('candidateApp.basicInfo.unaffiliatedDescription')}


### PR DESCRIPTION
## WHY:

Implements backend logic required for #184 

### What has been changed (if possible, add screenshots, gifs, etc. )

Adds two endpoints (/api/candidate/check, /api/candidate/register) that can be used for the registration key logic when registering an initial candidate. Additionally, fixes the majority of prettier warnings.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?
