### PR TITLE
fix: reactivity issues in components and templates

### DIFF
--- a/docs/contributing/style-guides.md
+++ b/docs/contributing/style-guides.md
@@ -26,6 +26,37 @@ Put each component in its own folder in `$lib/components`. Multiple components t
 
 Currently, most components use attribute forwarding with [Svelte's `$$restProps` variable](https://svelte.dev/docs/basic-markup#attributes-and-props). This means that any HTML or SVG attributes that the main element of the component accepts can be passed as the components properties – or, in case of a component derived from another Svelte component, the parent components properties. See the examples for details on how this is done.
 
+#### Default values for properties included `$$restProps`
+
+In most cases, default values for properties included in `$$restProps`, such as `aria-hidden` can be just added as attributes in the relevant element or component. The only thing to keep in mind is that they must precede `$$restProps`, otherwise they will override the values in it. For example:
+
+```tsx
+<div aria-label="Default label" {...$$restProps}>...</div>
+```
+
+However, if you want to concatenate values with properties in `$$restProps`, such as concatenating a default `class` string with one possibly defined in `$$restProps`, this should be added after `{...$$restProps}`. To make this easier, a `concatClass` helper function is provided in [`$lib/utils/components`](../../frontend/src/lib/utils/components.ts). For example:
+
+```tsx
+<div {...concatClass($$restProps, 'default-class')}>...</div>
+```
+
+#### Aria attributes and the `class` attribute
+
+Note that you most Aria attributes cannot be exposed with `let export foo` because their names contain dashes, which also applies to the HTML `class` attribute. In order to access these, either use the `$restProps` object or specify them in the properties type the component uses, i.e., the one assigned to `type $$Props` and access them via `$$props`. For example:
+
+```tsx
+// Foo.type.ts
+export type FooProps = SvelteHTMLElements['p'] & {
+  'aria-roledescription'?: string | null;
+  class?: string | null;
+};
+
+// Foo.svelte: <script>
+type $$Props = FooProps;
+let ariaDesc: $$Props['aria-roledescription'] = $$props['aria-roledescription'];
+let className: $$Props['class'] = $$props['class'];
+```
+
 ### Documentation
 
 Follow Svelte's [guidelines for component documentation](https://svelte.dev/docs/faq#how-do-i-document-my-components). For an example, see [`IconBase`](../../frontend/src/lib/components/icon/base/IconBase.svelte) component and its associated [type definition](../../frontend/src/lib/components/icon/base/IconBase.type.ts).

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -66,7 +66,7 @@
   /* Drawer 
    * Fix screen height on iOS Safari */
   .drawer {
-    @apply h-screen;
+    @apply min-h-screen;
   }
 
   /* Custom styles */

--- a/frontend/src/lib/components/button/Button.type.ts
+++ b/frontend/src/lib/components/button/Button.type.ts
@@ -81,7 +81,7 @@ export type ButtonProps = LinkOrButtonElementProps & {
  */
 type LinkOrButtonElementProps =
   | WithRequired<SvelteHTMLElements['a'], 'href'>
-  | SvelteHTMLElements['button'];
+  | (SvelteHTMLElements['button'] & {href?: null});
 
 /**
  * Make specific properties of an interface required. Works the same way as

--- a/frontend/src/lib/components/headingGroup/HeadingGroup.svelte
+++ b/frontend/src/lib/components/headingGroup/HeadingGroup.svelte
@@ -3,9 +3,6 @@
   import type {HeadingGroupProps} from './HeadingGroup.type';
 
   type $$Props = HeadingGroupProps;
-
-  $$restProps['role'] ??= 'group';
-  $$restProps['aria-roledescription'] ??= $_('aria.headingGroup');
 </script>
 
 <!--
@@ -36,6 +33,6 @@ and the main title.
 ```
 -->
 
-<hgroup {...$$restProps}>
+<hgroup aria-roledescription={$_('aria.headingGroup')} role="group" {...$$restProps}>
   <slot />
 </hgroup>

--- a/frontend/src/lib/components/headingGroup/HeadingGroup.type.ts
+++ b/frontend/src/lib/components/headingGroup/HeadingGroup.type.ts
@@ -1,15 +1,2 @@
-import type {AriaRole, SvelteHTMLElements} from 'svelte/elements';
-export type HeadingGroupProps = SvelteHTMLElements['hgroup'] & {
-  /**
-   * The Aria role description of the `<hgroup>` element.
-   *
-   * @default $_('aria.headingGroup')
-   */
-  'aria-roledescription'?: string | null;
-  /**
-   * The Aria role of the `<hgroup>` element.
-   *
-   * @default 'group'
-   */
-  role?: AriaRole | null;
-};
+import type {SvelteHTMLElements} from 'svelte/elements';
+export type HeadingGroupProps = SvelteHTMLElements['hgroup'];

--- a/frontend/src/lib/components/headingGroup/PreHeading.svelte
+++ b/frontend/src/lib/components/headingGroup/PreHeading.svelte
@@ -3,8 +3,6 @@
   import type {PreHeadingProps} from './PreHeading.type';
 
   type $$Props = PreHeadingProps;
-
-  $$restProps['aria-roledescription'] ??= $_('aria.preHeading');
 </script>
 
 <!--
@@ -30,6 +28,6 @@ within a `HeadingGroup`.
 ```
 -->
 
-<p {...$$restProps}>
+<p aria-roledescription={$_('aria.preHeading')} {...$$restProps}>
   <slot />
 </p>

--- a/frontend/src/lib/components/headingGroup/PreHeading.type.ts
+++ b/frontend/src/lib/components/headingGroup/PreHeading.type.ts
@@ -1,10 +1,2 @@
 import type {SvelteHTMLElements} from 'svelte/elements';
-export type PreHeadingProps = SvelteHTMLElements['p'] & {
-  /**
-   * The Aria role description of the `<p>` element representing
-   * the pre-title.
-   *
-   * @default $_('aria.preHeading')
-   */
-  'aria-roledescription'?: string | null;
-};
+export type PreHeadingProps = SvelteHTMLElements['p'];

--- a/frontend/src/lib/components/heroEmoji/HeroEmoji.svelte
+++ b/frontend/src/lib/components/heroEmoji/HeroEmoji.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
+  import {concatClass} from '$lib/utils/components';
   import type {HeroEmojiProps} from './HeroEmoji.type';
 
   type $$Props = HeroEmojiProps;
-
-  // Merge the necessary classes to possible extra classes defined in the props
-  $$restProps.class = `whitespace-nowrap truncate text-clip text-center font-emoji text-[6.5rem] leading-none ${
-    $$restProps.class ?? ''
-  }`;
 </script>
 
 <!--
@@ -25,6 +21,9 @@ using the `class` attribute, e.g. `class="text-[10rem]"`.
 
 ### Properties
 
+- `aria-hidden`: @default `true`
+- `role`: Aria role @default `img`
+- `class`: Additional class string to append to the element's default classes.
 - Any valid attributes of a `<div>` element.
 
 ### Slots
@@ -38,4 +37,12 @@ using the `class` attribute, e.g. `class="text-[10rem]"`.
 ```
 -->
 
-<div role="img" aria-hidden="true" {...$$restProps}><slot /></div>
+<div
+  aria-hidden="true"
+  role="img"
+  {...concatClass(
+    $$restProps,
+    'whitespace-nowrap truncate text-clip text-center font-emoji text-[6.5rem] leading-none'
+  )}>
+  <slot />
+</div>

--- a/frontend/src/lib/components/icon/Icon.svelte
+++ b/frontend/src/lib/components/icon/Icon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {onMount} from 'svelte';
+  import {concatClass} from '$lib/utils/components';
   import type {IconProps} from './Icon.type';
   import {ICONS} from './icons';
 
@@ -8,44 +8,40 @@
   export let size: $$Props['size'] = 'md';
   export let color: $$Props['color'] = 'current';
 
-  // Validate name and split path
-  // We need this part-wise approach because of Vite's dynamic import limitations
-  // https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations
-  const [folder, filename] = name in ICONS ? ICONS[name] : ['custom', 'missing_icon'];
-
   // Load svg contents
   let svgElement: SVGElement;
-  // The import happens inside onMount to make sure the SVG element is available
-  onMount(() =>
-    import(`./svg/${folder}/${filename}.ts`).then((svg) => {
-      if (svgElement) {
-        svgElement.innerHTML = svg.default;
-      }
-    })
-  );
+  // Pass svgElement and name explicitly to trigger correct reactivity
+  $: loadSvg(svgElement, name);
+
+  function loadSvg(svgElement: SVGElement, name: $$Props['name']) {
+    if (!svgElement || !name) return;
+    // Validate name and split path
+    // We need this part-wise approach because of Vite's dynamic import limitations
+    // https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations
+    const [folder, filename] = name in ICONS ? ICONS[name] : ['custom', 'missing_icon'];
+    import(`./svg/${folder}/${filename}.ts`).then((svg) => (svgElement.innerHTML = svg.default));
+  }
 
   // Create class names
-  let classes = 'inline-block';
-
-  // Predefined sizes
-  switch (size) {
-    case 'sm':
-      classes += ' h-16 w-16';
-      break;
-    case 'lg':
-      classes += ' h-32 w-32';
-      break;
-    default:
-      classes += ' h-24 w-24';
+  let classes: string;
+  $: {
+    classes = 'inline-block';
+    // Predefined sizes
+    switch (size) {
+      case 'sm':
+        classes += ' h-16 w-16';
+        break;
+      case 'lg':
+        classes += ' h-32 w-32';
+        break;
+      default:
+        classes += ' h-24 w-24';
+    }
+    // Set fill color
+    if (color != null) {
+      classes += ` fill-${color}`;
+    }
   }
-
-  // Set fill color
-  if (color != null) {
-    classes += ` fill-${color}`;
-  }
-
-  // Merge classes into $$restProps
-  $$restProps.class = `${classes} ${$$restProps.class ?? ''}`;
 </script>
 
 <!--
@@ -56,9 +52,22 @@ Use the other properties to set the size and color of the icon. The icon
 is `aria-hidden` by default, but that can overriden. You can also pass 
 any valid attributes of the `<svg>` element.
 
+NB! The component does not currently support reactive updates to `name`,
+`size` or `color`. Use within a `#key` block if you need to change these.
+
 ### Properties
 
-- See `Icon.type.ts` or code completion info.
+- `name`: the name of the icon to use
+- `size`: The size of the icon as one of the predefined sizes 'sm', 'md' or 'lg'.
+   For arbitrary values, you can supply a `class` property, such as 
+   `h-[3.15rem] w-[3.15rem]`. @default 'md'
+- `color`: The color of the icon as one of the predefined colours.
+   For arbitrary values, you can supply a `class` property, such as
+   `fill-[#123456]`. @default 'current'
+- `aria-hidden`: @default `true`
+- `role`: Aria role @default `img`
+- `class`: Additional class string to append to the element's default classes.
+- Any valid attributes of a `<svg>` element
 
 ### Usage
 
@@ -71,8 +80,8 @@ any valid attributes of the `<svg>` element.
 
 <svg
   bind:this={svgElement}
-  role="img"
   aria-hidden="true"
+  role="img"
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 24 24"
-  {...$$restProps} />
+  {...concatClass($$restProps, classes)} />

--- a/frontend/src/lib/components/navigation/NavGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavGroup.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
+  import {concatClass} from '$lib/utils/components';
   import type {NavGroupProps} from './NavGroup.type';
 
   type $$Props = NavGroupProps;
-
-  // Merge classes into $$restProps
-  $$restProps.class = `before:content-[''] before:mx-16 before:my-md before:block before:border-t-md before:border-t-[var(--line-color)] ${
-    $$restProps.class ?? ''
-  }`;
 </script>
 
 <!--
 @component
-TBA
+Use to group `NavItem` components. Displays a faint line above the group.
 
 ### Slots
 
@@ -20,6 +16,8 @@ TBA
 
 ### Properties
 
+- `role`: Aria role @default `list`
+- `class`: Additional class string to append to the element's default classes.
 - Any valid attributes of a `<section>` element.
 
 ### Usage
@@ -38,6 +36,11 @@ TBA
   invalid content for such an element. See: 
   https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role -->
 
-<section role="list" {...$$restProps}>
+<section
+  role="list"
+  {...concatClass(
+    $$restProps,
+    'before:content-[""] before:mx-16 before:my-md before:block before:border-t-md before:border-t-[var(--line-color)]'
+  )}>
   <slot />
 </section>

--- a/frontend/src/lib/components/navigation/NavItem.svelte
+++ b/frontend/src/lib/components/navigation/NavItem.svelte
@@ -1,24 +1,25 @@
 <script lang="ts">
+  import {concatClass} from '$lib/utils/components';
   import {Icon} from '$lib/components/icon';
   import type {NavItemProps} from './NavItem.type';
 
   type $$Props = NavItemProps;
 
+  export let href: $$Props['href'] = undefined;
   export let icon: $$Props['icon'] = undefined;
   export let text: $$Props['text'];
 
-  // Element type
-  const tagName = $$restProps['href'] ? 'a' : 'button';
-
-  // Merge classes into $$restProps
-  let classes =
-    'flex items-center gap-md px-16 py-md min-h-touch min-w-touch w-full !text-neutral hover:bg-base-200 active:bg-base-200';
-  if (!icon) {
-    // This corresponds to the width of an icon (24/16 rem) and the gap
-    // between the icon and the text (md = 10/16 rem)
-    classes += ' pl-[3.125rem]';
+  // Create classes
+  let classes: string;
+  $: {
+    classes =
+      'flex items-center gap-md px-16 py-md min-h-touch min-w-touch w-full !text-neutral hover:bg-base-200 active:bg-base-200';
+    if (!icon) {
+      // This corresponds to the width of an icon (24/16 rem) and the gap
+      // between the icon and the text (md = 10/16 rem)
+      classes += ' pl-[3.125rem]';
+    }
   }
-  $$restProps.class = `${classes} ${$$restProps.class ?? ''}`;
 </script>
 
 <!--
@@ -37,6 +38,7 @@ handler or other way of making the item interactive.
   interactive.
 - `icon`: An optional `IconName` of the icon to use. @default `undefined`
 - `text`: A required text to display.
+- `class`: Additional class string to append to the element's default classes.
 - Any valid attributes of either an `<a>` or `<button>` element depending
   whether `href` was defined or not, respectively.
 
@@ -53,7 +55,11 @@ handler or other way of making the item interactive.
   because we can't change the role of `<ActionItem>`, which renders as
   an `<a>` or `<button>` and thus already has a defined Aria role. -->
 <div role="listitem">
-  <svelte:element this={tagName} on:click {...$$restProps}>
+  <svelte:element
+    this={href == null ? 'button' : 'a'}
+    {href}
+    on:click
+    {...concatClass($$restProps, classes)}>
     {#if icon}
       <Icon name={icon} />
     {/if}

--- a/frontend/src/lib/components/navigation/NavItem.type.ts
+++ b/frontend/src/lib/components/navigation/NavItem.type.ts
@@ -4,7 +4,7 @@ import type {IconName} from '$lib/components/icon';
 /**
  * The properties of a navigation item.
  */
-export type NavItemProps = LinkOrButtonProps & {
+export type NavItemProps = LinkOrButtonElementProps & {
   /**
    * The optional name of the icon to use with the navigation item.
    * See the `Icon` component for more details.
@@ -21,9 +21,9 @@ export type NavItemProps = LinkOrButtonProps & {
  * element with the `href` attribute, or a `<button>` element, preferably
  * with the `on:click` event handler.
  */
-type LinkOrButtonProps =
+type LinkOrButtonElementProps =
   | WithRequired<SvelteHTMLElements['a'], 'href'>
-  | SvelteHTMLElements['button'];
+  | (SvelteHTMLElements['button'] & {href?: null});
 
 /**
  * Make specific properties of an interface required. Works the same way as

--- a/frontend/src/lib/templates/basicPage/BasicPage.svelte
+++ b/frontend/src/lib/templates/basicPage/BasicPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {_} from 'svelte-i18n';
+  import {concatProps} from '$lib/utils/components';
   import {Page} from '../page';
   import type {BasicPageProps} from './BasicPage.type';
 
@@ -9,9 +10,6 @@
   export let noteClass: $$Props['noteClass'] = 'text-secondary text-center';
   export let noteRole: $$Props['noteRole'] = 'note';
   export let primaryActionsLabel: $$Props['primaryActionsLabel'] = $_('aria.primaryActionsLabel');
-
-  // Merge restProps classes
-  $$restProps.mainClass = `gap-y-lg ${$$restProps.mainClass ?? ''}`;
 </script>
 
 <!--
@@ -49,6 +47,7 @@ is based on.
 - `primaryActionsLabel?`: Optional `aria-label` for the section that contains the primary page
   actions.
   @default $_('aria.primaryActionsLabel')
+- `mainClass`: Additional class string to append to the `Page` template's `mainClass`
 - Any valid properties of the `Page` template.
 
 ### Usage
@@ -83,7 +82,7 @@ is based on.
 ```
 -->
 
-<Page {title} {...$$restProps}>
+<Page {title} {...concatProps($$restProps, {mainClass: 'gap-y-lg'})}>
   <!-- Header -->
   <slot name="banner" slot="banner" />
 

--- a/frontend/src/lib/templates/frontPage/FrontPage.svelte
+++ b/frontend/src/lib/templates/frontPage/FrontPage.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
+  import {concatProps} from '$lib/utils/components';
   import {Page} from '../page';
   import type {FrontPageProps} from './FrontPage.type';
 
   type $$Props = FrontPageProps;
 
   export let title: $$Props['title'];
-
-  // Merge default values to $$restProps
-  $$restProps.class = `bg-base-300 ${$$restProps.class ?? ''}`;
-  $$restProps.headerClass = `!absolute w-full bg-transparent ${$$restProps.headerClass ?? ''}`;
-  $$restProps.mainClass = `!p-0 ${$$restProps.mainClass ?? ''}`;
 </script>
 
 <!--
@@ -31,12 +27,15 @@ is based on.
   side of the `<header>`
 - `hero`: an optional hero image
 - `heading`: optional content for the main title block, defaults to a 
-`<h1>` element containing the required `title` property
-  - `footer`: the footer to display at the bottom of the page
+  `<h1>` element containing the required `title` property
+- `footer`: the footer to display at the bottom of the page
     
 ### Properties
 
 - `title`: The required page `title`.
+- `class`: Additional class string to append to the element's default classes.
+- `headerClass`: Additional class string to append to the `Page` template's `headerClass`.
+- `mainClass`: Additional class string to append to the `Page` template's `mainClass`.
 - Any valid properties of the `Page` template.
 
 ### Usage
@@ -67,7 +66,13 @@ is based on.
 ```
 -->
 
-<Page {title} {...$$restProps}>
+<Page
+  {title}
+  {...concatProps($$restProps, {
+    class: 'bg-base-300',
+    headerClass: '!absolute w-full bg-transparent',
+    mainClass: '!p-0'
+  })}>
   <!-- Header -->
   <slot name="header" slot="banner" />
 

--- a/frontend/src/lib/templates/page/Page.svelte
+++ b/frontend/src/lib/templates/page/Page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {_} from 'svelte-i18n';
   import {page} from '$app/stores';
+  import {concatClass} from '$lib/utils/components';
   import {appType} from '$lib/utils/stores';
   import {Icon} from '$lib/components/icon';
   import {NavItem} from '$lib/components/navigation';
@@ -46,9 +47,6 @@
     drawerOpen = false;
     drawerOpenElement?.focus();
   }
-
-  // Merge the necessary drawer class to possible extra classes defined in the props
-  $$restProps.class = `drawer ${$$restProps.class ?? ''}`;
 
   // TODO: Fix progress bar color on iOS Safari:
   // see https://stackoverflow.com/questions/38622911/styling-meter-bar-for-mozilla-and-safari
@@ -112,6 +110,8 @@ the Drawer component.
   @default 100
 - `progressTitle?`: Optional title for the progress bar.
   @default `$_('header.progressTitle')`
+- `class`: Additional class string to append to the element's default classes.
+- Any valid attributes of a `<div>` element.
 
 ### Usage
 
@@ -135,7 +135,7 @@ the Drawer component.
 <a href="#{mainId}" class="sr-only focus:not-sr-only">{skipLinkLabel}</a>
 
 <!-- Drawer container -->
-<div {...$$restProps}>
+<div {...concatClass($$restProps, 'drawer')}>
   <!-- NB. The Wave ARIA checker will show an error for this, but the use of both the 
     non-hidden labels in aria-labelledby should be okay for screen readers. -->
   <input
@@ -157,7 +157,7 @@ the Drawer component.
         aria-expanded={drawerOpen}
         aria-controls={navId}
         aria-label={drawerOpenLabel}
-        class="btn-ghost drawer-button btn flex cursor-pointer items-center gap-md text-neutral">
+        class="btn-ghost btn drawer-button flex cursor-pointer items-center gap-md text-neutral">
         <slot name="drawerOpenButton">
           <Icon name="menu" />
           <AppLogo aria-hidden="true" alt="" />

--- a/frontend/src/lib/templates/page/Page.svelte
+++ b/frontend/src/lib/templates/page/Page.svelte
@@ -157,7 +157,7 @@ the Drawer component.
         aria-expanded={drawerOpen}
         aria-controls={navId}
         aria-label={drawerOpenLabel}
-        class="btn-ghost btn drawer-button flex cursor-pointer items-center gap-md text-neutral">
+        class="btn-ghost drawer-button btn flex cursor-pointer items-center gap-md text-neutral">
         <slot name="drawerOpenButton">
           <Icon name="menu" />
           <AppLogo aria-hidden="true" alt="" />
@@ -192,7 +192,7 @@ the Drawer component.
     <svelte:component
       this={$appType === 'candidate' ? CandidateNav : VoterNav}
       on:navFocusOut={closeDrawer}
-      class="menu w-4/5 max-w-sm bg-base-100 {drawerOpen ? '' : 'hidden'}"
+      class="h-full w-4/5 max-w-sm bg-base-100 {drawerOpen ? '' : 'hidden'}"
       id={navId}>
       <NavItem
         on:click={closeDrawer}

--- a/frontend/src/lib/templates/parts/appLogo/AppLogo.svelte
+++ b/frontend/src/lib/templates/parts/appLogo/AppLogo.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import {concatClass} from '$lib/utils/components';
   import normalLogo from './svg/openvaa-logo-grey.svg';
   import inverseLogo from './svg/openvaa-logo-white.svg';
   import type {AppLogoProps} from './AppLogo.type';
@@ -10,21 +11,19 @@
 
   // Create class names
   let classes: string;
-
-  // Predefined sizes
-  switch (size) {
-    case 'sm':
-      classes = 'h-20 pt-2';
-      break;
-    case 'lg':
-      classes = 'h-32 pt-6';
-      break;
-    default:
-      classes = 'h-24 pt-4';
+  $: {
+    // Predefined sizes
+    switch (size) {
+      case 'sm':
+        classes = 'h-20 pt-2';
+        break;
+      case 'lg':
+        classes = 'h-32 pt-6';
+        break;
+      default:
+        classes = 'h-24 pt-4';
+    }
   }
-
-  // Merge classes into restProps
-  $$restProps.class = `${classes} ${$$restProps.class ?? ''}`;
 
   // TODO: Use logo files defined in Strapi.
   // TODO: Render only one image, see issue #279
@@ -43,6 +42,7 @@ colour changes dynamically based on whether the light or dark mode is active.
 - `size`: The size of the logo as one of the predefined sizes 'sm', 'md' or 'lg'.
   For arbitrary values, you can supply a `class` attribute, such as 
   `class="h-[3.5rem]"`. @default `'md'`
+- `class`: Additional class string to append to the element's default classes.
 - Any valid attributes of the `<div>` element wrapping the light and dark
   `<img>` elements
 
@@ -56,7 +56,7 @@ colour changes dynamically based on whether the light or dark mode is active.
 ```
 -->
 
-<div {...$$restProps}>
+<div {...concatClass($$restProps, classes)}>
   <img src={normalLogo} {alt} class="h-full {inverse ? 'hidden dark:block' : 'dark:hidden'}" />
   <img src={inverseLogo} {alt} class="h-full {inverse ? 'dark:hidden' : 'hidden dark:block'}" />
 </div>

--- a/frontend/src/lib/templates/singleCardPage/SingleCardPage.svelte
+++ b/frontend/src/lib/templates/singleCardPage/SingleCardPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import {concatClass} from '$lib/utils/components';
   import {Page} from '../page';
   import type {SingleCardPageProps} from './SingleCardPage.type';
 
@@ -6,11 +7,10 @@
 
   export let cardClass: $$Props['cardClass'] = '';
 
-  // Merge restProps classes
-  $$restProps.class = `bg-base-300 ${$$restProps.class ?? ''}`;
-
   // We need this explicit typing to get rid of linter errors below
-  const props = $$restProps as SingleCardPageProps;
+  function _concatClass(props: SvelteRestProps, classes: string) {
+    return concatClass(props, classes) as SingleCardPageProps;
+  }
 </script>
 
 <!--
@@ -36,7 +36,9 @@ is based on.
 - `title`: The required page `title`.
 - `cardClass?`: Optional class string to add to the `<div>` tag that defines the
   card wrapping the `default` slot.
+- `class`: Additional class string to append to the element's default classes.
 - Any valid properties of the `Page` template.
+
 
 ### Usage
 
@@ -53,7 +55,7 @@ is based on.
 ```
 -->
 
-<Page {...props}>
+<Page {..._concatClass($$restProps, 'bg-base-300')}>
   <!-- Header -->
   <slot name="banner" slot="banner" />
 

--- a/frontend/src/lib/utils/components.ts
+++ b/frontend/src/lib/utils/components.ts
@@ -1,5 +1,38 @@
-function getUUID(): string {
+/** Create a unique identifier for use as an element ID. */
+export function getUUID(): string {
   return crypto?.randomUUID ? crypto.randomUUID() : (Math.random() * 10e15).toString(16);
 }
 
-export {getUUID};
+/**
+ * Concat string values with properties passed by the user. Mainly used to
+ * prepend default `class` values into `$$restProps` before passing them
+ * to an element or a Svelte component.
+ * @param props The passed properties, usually `$$restProps`
+ * @param defaults A record of string properties that will be prepended to the
+ *   same values in `props`
+ * @returns The merged props, based on a shallow copy of `props`
+ */
+export function concatProps<T extends Record<string, unknown>, D extends Record<string, string>>(
+  props: T,
+  defaults: D
+): Omit<T, keyof D> & D {
+  // Make a shallow copy of props so as not to alter its values
+  const merged: Record<string, unknown> = {...props};
+  for (const k in defaults) {
+    merged[k] =
+      k in merged && typeof merged[k] === 'string' ? `${defaults[k]} ${merged[k]}` : defaults[k];
+  }
+  return merged as Omit<T, keyof D> & D;
+}
+
+/**
+ * Prepend default class value into `$$restProps` before passing them
+ * to an element or a Svelte component. A shorthand for `concatProps`.
+ * @param props The passed properties, usually `$$restProps`
+ * @param classes The base classes to use
+ * @returns The merged props, based on a shallow copy of `props` with
+ *   `classes` joined with possible `props.class`
+ */
+export function concatClass<T extends Record<string, unknown>>(props: T, classes: string) {
+  return concatProps(props, {class: classes});
+}


### PR DESCRIPTION
## WHY:

Fixes: #278 

### What has been changed (if possible, add screenshots, gifs, etc. )

Components and templates using `$$restProps` forwarding had an issue with reactive
updates that would lead to layouts breaking. The reason for this was that the
`class` string used by the components were merged into `$$restProps` in a
non-reactive part of the component and the `$$restProps` was passed
directly to the component with the expectation that it would contain the proper
`class` string. However, any reactive updates would reinstantialize 
`$$restProps` and the alterations would no longer be included in it.

This issue became very prominent with the introduction of page templates,
because any reactive update to a page's contents, would break the layout
due to the loss of  `class="drawer"` in the `<div>` containing the page,
which was also described in #278.

In this update, default `class` strings are recombined with `$$restProps` on
reactive updates using a shared utility function (`concatClass`/`concatProps`).
In addition, the effects of some other styling-related custom properties of 
components, such as `size` and `color`, are made reactive as well.

Also includes a quick styling fix to the nav menu on `Page`, which is not
related to reactivity issues.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
