### PR TITLE
feat: forgot password backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ DATABASE_USERNAME=strapi
 DATABASE_PASSWORD=strapi
 DATABASE_SCHEMA=public
 DATABASE_SSL_SELF=false
+PUBLIC_FRONTEND_URL="http://localhost:5173" # Used for emails linking to the frontend
 
 # Set to true to enable mock data on an empty database
 GENERATE_MOCK_DATA_ON_INITIALISE=true

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,14 @@ DATABASE_SCHEMA=public
 DATABASE_SSL_SELF=false
 PUBLIC_FRONTEND_URL="http://localhost:5173" # Used for emails linking to the frontend
 
+# SMTP Settings
+SMTP_HOST="smtp.example.com"
+SMTP_PORT=587
+SMTP_USERNAME=""
+SMTP_PASSWORD=""
+MAIL_FROM="candidate-app@example.com"
+MAIL_REPLY_TO="candidate-app@example.com"
+
 # Set to true to enable mock data on an empty database
 GENERATE_MOCK_DATA_ON_INITIALISE=true
 

--- a/backend/vaa-strapi/config/env/development/plugins.ts
+++ b/backend/vaa-strapi/config/env/development/plugins.ts
@@ -1,0 +1,13 @@
+module.exports = ({env}) => ({
+  email: {
+    config: {
+      // Use the bundled maildev instance part of docker-compose
+      provider: 'nodemailer',
+      providerOptions: {
+        host: 'maildev',
+        port: 1025,
+        ignoreTLS: true
+      }
+    }
+  }
+});

--- a/backend/vaa-strapi/config/plugins.ts
+++ b/backend/vaa-strapi/config/plugins.ts
@@ -11,8 +11,8 @@ export default ({env}) => ({
         }
       },
       settings: {
-        defaultFrom: 'strapi@example.com',
-        defaultReplyTo: 'strapi@example.com'
+        defaultFrom: env('MAIL_FROM', 'candidate-app@example.com'),
+        defaultReplyTo: env('MAIL_REPLY_TO', 'candidate-app@example.com')
       }
     }
   }

--- a/backend/vaa-strapi/config/plugins.ts
+++ b/backend/vaa-strapi/config/plugins.ts
@@ -1,0 +1,19 @@
+export default ({env}) => ({
+  email: {
+    config: {
+      provider: 'nodemailer',
+      providerOptions: {
+        host: env('SMTP_HOST', 'smtp.example.com'),
+        port: env('SMTP_PORT', 587),
+        auth: {
+          user: env('SMTP_USERNAME'),
+          pass: env('SMTP_PASSWORD')
+        }
+      },
+      settings: {
+        defaultFrom: 'strapi@example.com',
+        defaultReplyTo: 'strapi@example.com'
+      }
+    }
+  }
+});

--- a/backend/vaa-strapi/package.json
+++ b/backend/vaa-strapi/package.json
@@ -24,6 +24,7 @@
     "@strapi/plugin-documentation": "^4.11.7",
     "@strapi/plugin-i18n": "4.11.7",
     "@strapi/plugin-users-permissions": "4.12.1",
+    "@strapi/provider-email-nodemailer": "^4.15.5",
     "@strapi/strapi": "4.11.7",
     "better-sqlite3": "7.4.6",
     "pg": "^8.8.0"
@@ -42,15 +43,15 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-transform-modules-commonjs": "^7.19.6",
+    "@faker-js/faker": "^8.0.2",
     "@typescript-eslint/parser": "^5.58.0",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^8.5.0",
-    "@faker-js/faker": "^8.0.2",
     "jest": "^29.5.0",
     "lint-staged": "^13.0.4",
     "prettier": "^2.8.0",
-    "typescript": "^4.6.2",
     "sqlite3": "^5.1.2",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "typescript": "^4.6.2"
   }
 }

--- a/backend/vaa-strapi/src/extensions/users-permissions/content-types/user/schema.json
+++ b/backend/vaa-strapi/src/extensions/users-permissions/content-types/user/schema.json
@@ -70,9 +70,7 @@
       "relation": "oneToOne",
       "target": "api::candidate.candidate",
       "mappedBy": "user",
-      "configurable": false,
-      "private": true,
-      "searchable": false
+      "configurable": false
     }
   },
   "config": {

--- a/backend/vaa-strapi/yarn.lock
+++ b/backend/vaa-strapi/yarn.lock
@@ -1988,6 +1988,14 @@
   resolved "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.11.7.tgz"
   integrity sha512-UJCdoUBxIrTL4/VTi9z62507jVoyhOz/8m/T0zWsSeqwnSh9timWLWRt3MZwqmA4iCZLF9/+5HreiWy5395Fbg==
 
+"@strapi/provider-email-nodemailer@^4.15.5":
+  version "4.15.5"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-email-nodemailer/-/provider-email-nodemailer-4.15.5.tgz#92404b9cca924a147eb17adfbf1774685c242779"
+  integrity sha512-Q0bF7t3iniOMvRWH1T4AQCjJHrXo/PV3ltMugJzKaasKOvlPqnw53DfinsA9yHb1Qwq8XyMjWNILjmlaT+9sLw==
+  dependencies:
+    lodash "4.17.21"
+    nodemailer "6.9.1"
+
 "@strapi/provider-email-sendmail@4.11.7":
   version "4.11.7"
   resolved "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.11.7.tgz"
@@ -8143,6 +8151,11 @@ nodemailer-shared@1.1.0:
   integrity sha512-68xW5LSyPWv8R0GLm6veAvm7E+XFXkVgvE3FW0FGxNMMZqMkPFeGDVALfR1DPdSfcoO36PnW7q5AAOgFImEZGg==
   dependencies:
     nodemailer-fetch "1.6.0"
+
+nodemailer@6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.9.1.tgz#8249d928a43ed85fec17b13d2870c8f758a126ed"
+  integrity sha512-qHw7dOiU5UKNnQpXktdgQ1d3OFgRAekuvbJLcdG5dnEo/GtcTHRYM7+UfJARdOFU9WUQO8OiIamgWPmiSFHYAA==
 
 noms@0.0.0:
   version "0.0.0"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,6 +39,12 @@ services:
       POSTGRES_DB: ${DATABASE_NAME}
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+  maildev:
+    image: maildev/maildev:2.1.0
+    ports:
+      - "127.0.0.1:1080:1080"
+    environment:
+      - MAILDEV_IP=0.0.0.0
 
 volumes:
   postgres:

--- a/docs/admin-guide/candidate-app.md
+++ b/docs/admin-guide/candidate-app.md
@@ -26,7 +26,7 @@ You can create a new user using the "Create new entry" button. The following fie
 Then, use the "Save" button and you should be able to log in as the candidate at http://localhost:5173/candidate.
 
 ## Resetting Password
-The user gets an email with a link to reset their password using the forgot password functionality on the login page. The frontend URL in the emails is configured with in `.env` with the PUBLIC_FRONTEND_URL variable, and the SMTP can be configured using the following variables:
+The user gets an email with a link to reset their password using the forgot password functionality on the login page. The frontend URL in the emails is configured in `.env` with the PUBLIC_FRONTEND_URL variable, and the SMTP can be configured using the following variables:
 - `SMTP_HOST`: the hostname the SMTP server runs on
 - `SMTP_PORT`: the port of the SMTP server
 - `SMTP_USERNAME`: the username used for authentication

--- a/docs/admin-guide/candidate-app.md
+++ b/docs/admin-guide/candidate-app.md
@@ -25,3 +25,13 @@ You can create a new user using the "Create new entry" button. The following fie
 
 Then, use the "Save" button and you should be able to log in as the candidate at http://localhost:5173/candidate.
 
+## Resetting Password
+The user gets an email with a link to reset their password using the forgot password functionality on the login page. The frontend URL in the emails is configured with in `.env` with the PUBLIC_FRONTEND_URL variable, and the SMTP can be configured using the following variables:
+- `SMTP_HOST`: the hostname the SMTP server runs on
+- `SMTP_PORT`: the port of the SMTP server
+- `SMTP_USERNAME`: the username used for authentication
+- `SMTP_PASSWORD`: the password used for authentication
+- `MAIL_FROM`: the email address the emails are sent from
+- `MAIL_REPLY_TO`: the email address replies should be sent to
+
+In a development environment, there is a local instance of [maildev](https://github.com/maildev/maildev) running so that you do not need to set up SMTP. The development configuration automatically enforces the use of maildev through the `backend/vaa-strapi/config/env/development/plugins.ts` file. The user interface of maildev can be found at [http://localhost:1080](http://localhost:1080), where you'll find any emails sent by Strapi.

--- a/frontend/src/lib/api/candidate.ts
+++ b/frontend/src/lib/api/candidate.ts
@@ -28,6 +28,37 @@ export const register = async (registrationKey: string, password: string): Promi
   });
 };
 
+export const requestForgotPasswordLink = async (email: string): Promise<Response> => {
+  const url = new URL(constants.PUBLIC_BACKEND_URL);
+  url.pathname = 'api/auth/forgot-password';
+
+  return await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({email})
+  });
+};
+
+export const resetPassword = async (code: string, password: string) => {
+  const url = new URL(constants.PUBLIC_BACKEND_URL);
+  url.pathname = 'api/auth/reset-password';
+
+  return await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      code: code,
+      password: password,
+      // We leave it up to the UI to do the validation if the password confirmation is correct
+      passwordConfirmation: password
+    })
+  });
+};
+
 export const checkRegistrationKey = async (registrationKey: string): Promise<Response> => {
   const url = new URL(constants.PUBLIC_BACKEND_URL);
   url.pathname = 'api/auth/candidate/check';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "scripts": {
         "dev":"docker compose -f docker-compose.dev.yml up -d --force-recreate --build",
         "dev:attach":"docker compose -f docker-compose.dev.yml up --force-recreate --build",
-        "dev:down": "docker compose -f docker-compose.dev.yml down -v --remove-orphans",
+        "dev:down": "docker compose -f docker-compose.dev.yml down --remove-orphans",
         "dev:stop": "docker compose -f docker-compose.dev.yml stop",
         "prepare":"husky install",
         "prod": "docker compose -f docker-compose.yml -p vaa-prod up -d --build"


### PR DESCRIPTION
## WHY:

Introduced the required backend logic for #189 

### What has been changed (if possible, add screenshots, gifs, etc. )

Added SMTP configuration and a maildev container for local development so that developers do not need to use real credentials. Additionally, this removes the `-v` flag from the `dev:down` command due to it deleting the volumes (and thus all Strapi data).

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
