### PR TITLE
build: fix Eslint and Prettier conflicts

### DIFF
--- a/backend/vaa-strapi/.eslintrc.json
+++ b/backend/vaa-strapi/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parser": "@typescript-eslint/parser",
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended", "prettier"],
   "env": {
     "commonjs": true,
     "es2017": true,
@@ -21,11 +21,8 @@
     "strapi": true
   },
   "rules": {
-    "indent": ["error", 2, {"SwitchCase": 1}],
-    "linebreak-style": ["error", "unix"],
     "no-console": ["error", {"allow": ["info", "warn", "error"]}],
-    "quotes": ["error", "single"],
-    "semi": ["error", "always"],
-    "no-unused-vars": "warn"
+    "no-unused-vars": "warn",
+    "quotes": ["error", "single", {"avoidEscape": true, "allowTemplateLiterals": false}]
   }
 }

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -26,11 +26,8 @@
     "jest": true
   },
   "rules": {
-    "indent": ["error", 2, {"SwitchCase": 1}],
-    "linebreak-style": ["error", "unix"],
     "no-console": ["error", {"allow": ["warn", "error", "info"]}],
     "no-undef": "off",
-    "quotes": ["error", "single", {"avoidEscape": true}],
-    "semi": ["error", "always"]
+    "quotes": ["error", "single", {"avoidEscape": true, "allowTemplateLiterals": false}]
   }
 }

--- a/frontend/src/routes/_test/+page.svelte
+++ b/frontend/src/routes/_test/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  const testA = [1, 2, 3];
+  // Test ternary formatting
+  const test = testA ? testA.filter((a) => a > 2).map((a) => a * 2) : [];
+</script>
+
+Foo {test}


### PR DESCRIPTION
## WHY:

Fixes #323 

### What has been changed (if possible, add screenshots, gifs, etc. )

Conflicts Eslint's and Prettier's opinions cause some checks always to fail.

Running on the automatic check `npx eslint-config-prettier ./frontend/.eslintrc.json` reports:

```
The following rules are unnecessary or might conflict with Prettier:

- indent
- linebreak-style
- semi

The following rules are enabled but cannot be automatically checked. See:
https://github.com/prettier/eslint-config-prettier#special-rules

- quotes
```

This is due to the fact that `eslint-config-prettier` cannot automatically turn off rules, only defaults.

To fix, the first three rules need to be removed, and the `quotes` one edited and kept in sync with Prettier:

Eslint:

```
{
  "rules": {
    "quotes": [
      "error",
      "single",
      { "avoidEscape": true, "allowTemplateLiterals": false }
    ]
  }
}
```

Prettier:

```
{
  "singleQuote": true
}
```

In the backend config, the Eslint config also needs to `extend` `prettier`.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
