### PR TITLE
Feat: fillingInfo fields to strapi (#201)

### DIFF
--- a/backend/vaa-strapi/src/api/candidate-attribute/content-types/candidate-attribute/schema.json
+++ b/backend/vaa-strapi/src/api/candidate-attribute/content-types/candidate-attribute/schema.json
@@ -49,6 +49,14 @@
         }
       },
       "type": "string"
+    },
+    "fillingInfo": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "text"
     }
   }
 }

--- a/backend/vaa-strapi/src/api/question/content-types/question/schema.json
+++ b/backend/vaa-strapi/src/api/question/content-types/question/schema.json
@@ -33,6 +33,14 @@
       },
       "type": "richtext"
     },
+    "fillingInfo": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "text"
+    },
     "questionType": {
       "type": "relation",
       "relation": "manyToOne",

--- a/backend/vaa-strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/vaa-strapi/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2023-12-18T20:46:11.897Z"
+    "x-generation-date": "2024-01-23T12:43:41.112Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -1303,6 +1303,9 @@
                                                               "type": "string"
                                                             },
                                                             "info": {
+                                                              "type": "string"
+                                                            },
+                                                            "fillingInfo": {
                                                               "type": "string"
                                                             },
                                                             "questionType": {
@@ -2771,6 +2774,9 @@
                                       "type": "string"
                                     },
                                     "value": {
+                                      "type": "string"
+                                    },
+                                    "fillingInfo": {
                                       "type": "string"
                                     },
                                     "createdAt": {
@@ -4598,6 +4604,9 @@
                                                               "info": {
                                                                 "type": "string"
                                                               },
+                                                              "fillingInfo": {
+                                                                "type": "string"
+                                                              },
                                                               "questionType": {
                                                                 "type": "object",
                                                                 "properties": {
@@ -5959,6 +5968,9 @@
                                                   "value": {
                                                     "type": "string"
                                                   },
+                                                  "fillingInfo": {
+                                                    "type": "string"
+                                                  },
                                                   "createdAt": {
                                                     "type": "string",
                                                     "format": "date-time"
@@ -6400,6 +6412,9 @@
           "value": {
             "type": "string"
           },
+          "fillingInfo": {
+            "type": "string"
+          },
           "locale": {
             "type": "string"
           }
@@ -6443,6 +6458,9 @@
                 "type": "string"
               },
               "value": {
+                "type": "string"
+              },
+              "fillingInfo": {
                 "type": "string"
               },
               "locale": {
@@ -6609,6 +6627,9 @@
                                       "type": "string"
                                     },
                                     "info": {
+                                      "type": "string"
+                                    },
+                                    "fillingInfo": {
                                       "type": "string"
                                     },
                                     "questionType": {
@@ -8785,6 +8806,9 @@
                                                                             "value": {
                                                                               "type": "string"
                                                                             },
+                                                                            "fillingInfo": {
+                                                                              "type": "string"
+                                                                            },
                                                                             "createdAt": {
                                                                               "type": "string",
                                                                               "format": "date-time"
@@ -9184,6 +9208,9 @@
             "type": "string"
           },
           "value": {
+            "type": "string"
+          },
+          "fillingInfo": {
             "type": "string"
           },
           "createdAt": {
@@ -10888,6 +10915,9 @@
                                                                                                       "info": {
                                                                                                         "type": "string"
                                                                                                       },
+                                                                                                      "fillingInfo": {
+                                                                                                        "type": "string"
+                                                                                                      },
                                                                                                       "questionType": {
                                                                                                         "type": "object",
                                                                                                         "properties": {
@@ -11730,6 +11760,9 @@
                                                                                 "type": "string"
                                                                               },
                                                                               "value": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "fillingInfo": {
                                                                                 "type": "string"
                                                                               },
                                                                               "createdAt": {
@@ -13739,6 +13772,9 @@
                                                                                                                   "info": {
                                                                                                                     "type": "string"
                                                                                                                   },
+                                                                                                                  "fillingInfo": {
+                                                                                                                    "type": "string"
+                                                                                                                  },
                                                                                                                   "questionType": {
                                                                                                                     "type": "object",
                                                                                                                     "properties": {
@@ -14581,6 +14617,9 @@
                                                                                             "type": "string"
                                                                                           },
                                                                                           "value": {
+                                                                                            "type": "string"
+                                                                                          },
+                                                                                          "fillingInfo": {
                                                                                             "type": "string"
                                                                                           },
                                                                                           "createdAt": {
@@ -16880,6 +16919,9 @@
                                                                                                       "info": {
                                                                                                         "type": "string"
                                                                                                       },
+                                                                                                      "fillingInfo": {
+                                                                                                        "type": "string"
+                                                                                                      },
                                                                                                       "questionType": {
                                                                                                         "type": "object",
                                                                                                         "properties": {
@@ -17722,6 +17764,9 @@
                                                                                 "type": "string"
                                                                               },
                                                                               "value": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "fillingInfo": {
                                                                                 "type": "string"
                                                                               },
                                                                               "createdAt": {
@@ -20453,6 +20498,9 @@
                                                                                                     "info": {
                                                                                                       "type": "string"
                                                                                                     },
+                                                                                                    "fillingInfo": {
+                                                                                                      "type": "string"
+                                                                                                    },
                                                                                                     "questionType": {
                                                                                                       "type": "object",
                                                                                                       "properties": {
@@ -21295,6 +21343,9 @@
                                                                               "type": "string"
                                                                             },
                                                                             "value": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "fillingInfo": {
                                                                               "type": "string"
                                                                             },
                                                                             "createdAt": {
@@ -23264,6 +23315,9 @@
                                                               "info": {
                                                                 "type": "string"
                                                               },
+                                                              "fillingInfo": {
+                                                                "type": "string"
+                                                              },
                                                               "questionType": {
                                                                 "type": "object",
                                                                 "properties": {
@@ -24732,6 +24786,9 @@
                                       "value": {
                                         "type": "string"
                                       },
+                                      "fillingInfo": {
+                                        "type": "string"
+                                      },
                                       "createdAt": {
                                         "type": "string",
                                         "format": "date-time"
@@ -25002,6 +25059,9 @@
           "info": {
             "type": "string"
           },
+          "fillingInfo": {
+            "type": "string"
+          },
           "questionType": {
             "oneOf": [
               {
@@ -25059,6 +25119,9 @@
                 "type": "string"
               },
               "info": {
+                "type": "string"
+              },
+              "fillingInfo": {
                 "type": "string"
               },
               "questionType": {
@@ -25230,6 +25293,9 @@
           "info": {
             "type": "string"
           },
+          "fillingInfo": {
+            "type": "string"
+          },
           "questionType": {
             "type": "object",
             "properties": {
@@ -25267,6 +25333,9 @@
                                       "type": "string"
                                     },
                                     "info": {
+                                      "type": "string"
+                                    },
+                                    "fillingInfo": {
                                       "type": "string"
                                     },
                                     "questionType": {
@@ -27443,6 +27512,9 @@
                                                                             "value": {
                                                                               "type": "string"
                                                                             },
+                                                                            "fillingInfo": {
+                                                                              "type": "string"
+                                                                            },
                                                                             "createdAt": {
                                                                               "type": "string",
                                                                               "format": "date-time"
@@ -29545,6 +29617,9 @@
                                                                                                       "info": {
                                                                                                         "type": "string"
                                                                                                       },
+                                                                                                      "fillingInfo": {
+                                                                                                        "type": "string"
+                                                                                                      },
                                                                                                       "questionType": {
                                                                                                         "type": "object",
                                                                                                         "properties": {
@@ -30389,6 +30464,9 @@
                                                                               "value": {
                                                                                 "type": "string"
                                                                               },
+                                                                              "fillingInfo": {
+                                                                                "type": "string"
+                                                                              },
                                                                               "createdAt": {
                                                                                 "type": "string",
                                                                                 "format": "date-time"
@@ -31104,6 +31182,9 @@
                           "type": "string"
                         },
                         "info": {
+                          "type": "string"
+                        },
+                        "fillingInfo": {
                           "type": "string"
                         },
                         "questionType": {
@@ -33364,6 +33445,9 @@
                                                                   "type": "string"
                                                                 },
                                                                 "value": {
+                                                                  "type": "string"
+                                                                },
+                                                                "fillingInfo": {
                                                                   "type": "string"
                                                                 },
                                                                 "createdAt": {

--- a/backend/vaa-strapi/types/generated/contentTypes.d.ts
+++ b/backend/vaa-strapi/types/generated/contentTypes.d.ts
@@ -743,6 +743,12 @@ export interface ApiCandidateAttributeCandidateAttribute extends Schema.Collecti
           localized: true;
         };
       }>;
+    fillingInfo: Attribute.Text &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -1215,6 +1221,12 @@ export interface ApiQuestionQuestion extends Schema.CollectionType {
         };
       }>;
     info: Attribute.RichText &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    fillingInfo: Attribute.Text &
       Attribute.SetPluginOptions<{
         i18n: {
           localized: true;

--- a/frontend/src/lib/api/getData.ts
+++ b/frontend/src/lib/api/getData.ts
@@ -323,6 +323,7 @@ export const getQuestions = (): Promise<QuestionProps[]> => {
             type: typeName as QuestionType,
             category: d.attributes.questionCategory.data.attributes.name ?? '',
             info: d.attributes.info,
+            fillingInfo: d.attributes.fillingInfo,
             options
           })
         );

--- a/frontend/src/lib/api/getData.type.ts
+++ b/frontend/src/lib/api/getData.type.ts
@@ -103,6 +103,7 @@ export interface StrapiQuestionData {
   attributes: {
     text: string;
     info: string;
+    fillingInfo: string;
     questionCategory: {
       data: {
         attributes: {

--- a/frontend/src/lib/types/global.d.ts
+++ b/frontend/src/lib/types/global.d.ts
@@ -133,6 +133,7 @@ declare global {
     options: {key: number; label: string}[];
     category?: string;
     info?: string;
+    fillingInfo?: string;
   }
 
   /**


### PR DESCRIPTION
## WHY:

Advances [#201](https://github.com/OpenVAA/voting-advice-application/issues/201)

### What has been changed (if possible, add screenshots, gifs, etc. )

Adds fillingInfo field to the Question and Candidate Attributes content types in strapi.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
