### PR TITLE
feat: TextArea component with local autosave

### DIFF
--- a/frontend/src/lib/candidate/components/textArea/TextArea.svelte
+++ b/frontend/src/lib/candidate/components/textArea/TextArea.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import {onMount, onDestroy} from 'svelte';
+  import type {TextAreaProps} from './TextArea.type';
+
+  type $$Props = TextAreaProps;
+
+  export let id: $$Props['id'];
+  export let text: $$Props['text'];
+
+  export let headerText: $$Props['headerText'] = undefined;
+  export let localStorageId: $$Props['localStorageId'] = undefined;
+  export let previouslySaved: $$Props['previouslySaved'] = undefined;
+  export let rows: $$Props['rows'] = 4;
+  export let disabled: $$Props['disabled'] = false;
+
+  const SAVE_INTERVAL_MS = 1000;
+  let saveInterval: NodeJS.Timeout;
+  onMount(() => {
+    if (localStorageId) {
+      const savedText = localStorage.getItem(localStorageId);
+      if (savedText) {
+        text = savedText;
+      } else {
+        text = previouslySaved ?? '';
+      }
+      saveInterval = setInterval(() => {
+        saveToLocalStorage();
+      }, SAVE_INTERVAL_MS);
+    } else {
+      text = previouslySaved ?? '';
+    }
+  });
+
+  onDestroy(() => {
+    clearInterval(saveInterval);
+  });
+
+  const saveToLocalStorage = () => {
+    if (!localStorageId) {
+      return;
+    }
+
+    if (!text || text === '' || previouslySaved === text) {
+      // Remove from local storage if there is nothing to save
+      removeFromLocalStorage();
+      return;
+    }
+
+    localStorage.setItem(localStorageId, text.toString());
+  };
+
+  const removeFromLocalStorage = () => {
+    if (!localStorageId) {
+      return;
+    }
+    localStorage.removeItem(localStorageId);
+  };
+
+  // Used to clear the local storage from a parent component
+  export const deleteLocal = () => {
+    removeFromLocalStorage();
+  };
+</script>
+
+<!--
+@component
+TextArea is a text area component with a header and a local storage save feature.
+
+### Slots
+
+- header: Optional header for the text area, can be used instead of the default one.
+
+### Bindable functions
+
+- `deleteLocal`: Deletes the local storage for the text area. Used to clear the local storage from a parent component.
+
+### Properties
+
+- `id` (required): The id for the text area and its label.
+- `text` (required): Variable to bind the text area value to.
+- `headerText` (optional): The header text for the text area. If not provided, the header slot will be used.
+- `localStorageId` (optional): Local storage id for the saved text. If provided, content is saved to local storage periodically.
+- `previouslySaved` (optional): Previously saved text from the database, i.e. not locally saved. Is shown if there is no locally saved text.
+- `rows` (optional): The number of rows for the text area. Default is 4.
+- `disabled` (optional): Whether the text area is disabled. Default is false.
+
+### Usage
+
+Usage without local saving:
+
+```tsx
+<TextArea
+  headerText="Example Header"
+  id="example-id"
+  bind:text={exampleTextVariable} />
+```
+
+Usage with local saving:
+
+```tsx
+<TextArea
+  headerText="Example Header"
+  id="example-id"
+  localStorageId="example-id"
+  previouslySaved="Example text"
+  disabled={isDisabled}
+  bind:text={textVariable}
+  bind:this={textAreaVariable} />
+```
+-->
+
+<div class="w-full">
+  {#if headerText}
+    <label for={id} class="text-m mx-6 my-6 p-0 uppercase text-secondary">{headerText}</label>
+  {:else}
+    <slot name="header" field={undefined} />
+  {/if}
+
+  <textarea
+    {id}
+    {rows}
+    {disabled}
+    class="textarea my-6 w-full resize-none bg-base-100 p-6 !outline-none disabled:bg-base-300"
+    bind:value={text}
+    on:focusout={saveToLocalStorage} />
+</div>

--- a/frontend/src/lib/candidate/components/textArea/TextArea.type.ts
+++ b/frontend/src/lib/candidate/components/textArea/TextArea.type.ts
@@ -1,0 +1,36 @@
+export type TextAreaProps = {
+  /**
+   * The unique identifier for the text area.
+   */
+  id: string;
+  /**
+   * The text content of the text area.
+   */
+  text: string | Text | undefined;
+  /**
+   * The header text to be displayed above the textarea. If not provided, header slot will be used.
+   * @default undefined
+   */
+  headerText?: string;
+  /**
+   * The key used to store the textarea's content in local storage.
+   * @default undefined
+   */
+  localStorageId?: string;
+  /**
+   * Previously saved text content from the database.
+   * Is initially shown if nothing is in local storage.
+   * @default undefined
+   */
+  previouslySaved?: string | Text | undefined;
+  /**
+   * The number of rows in the textarea.
+   * @default 4
+   */
+  rows?: number;
+  /**
+   * Whether the textarea is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+};

--- a/frontend/src/lib/candidate/components/textArea/index.ts
+++ b/frontend/src/lib/candidate/components/textArea/index.ts
@@ -1,0 +1,2 @@
+export {default as TextArea} from './TextArea.svelte';
+export * from './TextArea.type';

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/profile/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/profile/+page.svelte
@@ -15,6 +15,7 @@
   import AvatarSelect from './AvatarSelect.svelte';
   import type {StrapiLanguageData} from '$lib/api/getData.type';
   import type {Language} from '$lib/types/candidateAttributes';
+  import {TextArea} from '$candidate/components/textArea';
 
   const basicInfoFields = ['firstName', 'lastName', 'party'];
 
@@ -43,6 +44,9 @@
   let manifesto = user?.candidate?.manifesto;
   const nominations = user?.candidate?.nominations;
 
+  let manifestoTextArea: TextArea; // Used to clear the local storage from the parent component
+  let savedManifesto = user?.candidate?.manifesto; // Used to detect changes in the manifesto
+
   // all necessary fields filled boolean
   $: allFilled =
     gender && motherTongues && motherTongues.length > 0 && birthday && manifesto ? true : false;
@@ -55,6 +59,11 @@
     try {
       await uploadPhoto();
       await updateBasicInfo(manifesto, birthday, gender, photo, unaffiliated, motherTongues);
+
+      // Update the database-saved manifesto in order to detect changes
+      savedManifesto = manifesto;
+      manifestoTextArea.deleteLocal();
+
       await loadUserData(); // reload user data so it's up to date
       await goto(getRoute(Route.CandAppQuestions));
     } catch (error) {
@@ -265,13 +274,15 @@
         </p>
       </FieldGroup>
       <FieldGroup>
-        <label for="message" class={headerClass} slot="header"
-          >{$t('candidateApp.basicInfo.electionManifesto')}</label>
-        <textarea
-          id="message"
-          rows="4"
-          class="w-full resize-none bg-base-100 p-6 !outline-none"
-          bind:value={manifesto} />
+        <TextArea
+          id="manifesto"
+          localStorageId="candidate-app-manifesto"
+          previouslySaved={savedManifesto}
+          bind:text={manifesto}
+          bind:this={manifestoTextArea}>
+          <label for="manifesto" class={headerClass} slot="header"
+            >{$t('candidateApp.basicInfo.electionManifesto')}</label>
+        </TextArea>
       </FieldGroup>
       <Button
         disabled={!allFilled}

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/[questionId]/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/[questionId]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import {onMount, onDestroy} from 'svelte';
   import {goto} from '$app/navigation';
   import {page} from '$app/stores';
   import {locale, t} from '$lib/i18n';
@@ -10,20 +9,7 @@
   import {LikertResponseButtons, QuestionActions, QuestionInfo} from '$lib/components/questions';
   import {BasicPage} from '$lib/templates/basicPage';
   import {translate} from '$lib/i18n/utils/translate';
-
-  const SAVE_INTERVAL_MS = 1000;
-
-  // Open answer is saved periodically to local storage
-  let saveInterval: NodeJS.Timeout;
-  onMount(() => {
-    saveInterval = setInterval(() => {
-      saveOpenAnswerToLocal();
-    }, SAVE_INTERVAL_MS);
-  });
-
-  onDestroy(() => {
-    clearInterval(saveInterval);
-  });
+  import {TextArea} from '$candidate/components/textArea';
 
   const store = answerContext.answers;
   $: answerStore = $store;
@@ -39,6 +25,9 @@
 
   $: answer = answerStore?.[questionId]; // null if not answered
 
+  let openAnswerTextArea: TextArea; // Used to clear the local storage from the parent component
+  let openAnswer = '';
+
   let selectedKey: AnswerOption['key'] | null;
 
   // Set the selected key on page load, local storage takes precedence
@@ -49,20 +38,6 @@
     } else {
       selectedKey = answer?.key ?? null;
     }
-
-    setOpenAnswer();
-  }
-
-  let openAnswer = '';
-
-  // Set open answer from local storage and answer store if available, local storage takes precedence
-  function setOpenAnswer() {
-    if (answer && !localStorage.getItem(openAnswerLocal)) {
-      // Quick fix to load in current locale
-      openAnswer = translate(answer.openAnswer);
-      return;
-    }
-    openAnswer = localStorage.getItem(openAnswerLocal) ?? '';
   }
 
   function saveLikertToLocal({detail}: CustomEvent) {
@@ -70,18 +45,9 @@
     localStorage.setItem(likertLocal, detail.value);
   }
 
-  function saveOpenAnswerToLocal() {
-    if (openAnswer === '' || translate(answer?.openAnswer) === openAnswer) {
-      localStorage.removeItem(openAnswerLocal);
-      return;
-    }
-
-    localStorage.setItem(openAnswerLocal, openAnswer);
-  }
-
   function removeLocalAnswerToQuestion() {
     localStorage.removeItem(likertLocal);
-    localStorage.removeItem(openAnswerLocal);
+    openAnswerTextArea.deleteLocal();
   }
 
   let errorMessage = '';
@@ -151,8 +117,8 @@
       }
     }
 
-    openAnswer = '';
     removeLocalAnswerToQuestion();
+    openAnswer = '';
     answerContext.answers.set(answerStore);
   }
 
@@ -177,13 +143,6 @@
 
     delete answerStore?.[questionId];
     answerContext.answers.set(answerStore);
-  }
-
-  // Skip to next question
-  // TODO: Later we might want to add an explicit note that this question was skipped
-  // TODO: This needs to take into account as well whether the question is already answered
-  function skipQuestion() {
-    gotoNextQuestion();
   }
 
   async function navigateToQuestion(indexChange: number, lastPageUrl: string) {
@@ -235,7 +194,7 @@
 
 {#if currentQuestion}
   {#key currentQuestion}
-    <BasicPage title={currentQuestion.text}>
+    <BasicPage title={currentQuestion.text} class="bg-base-200">
       <HeadingGroup slot="heading" id="hgroup-{currentQuestion.id}">
         {#if currentQuestion.category && currentQuestion.category !== ''}
           <!-- TODO: Set color based on category -->
@@ -260,18 +219,14 @@
           {$t('error.general')}
         {/if}
 
-        <div class="m-12 w-full items-start">
-          <label for="openAnswer" class="text-m uppercase"
-            >{$t('candidateApp.opinions.commentOnThisIssue')}
-          </label>
-          <textarea
-            bind:value={openAnswer}
-            on:focusout={saveOpenAnswerToLocal}
-            disabled={!selectedKey}
-            id="openAnswer"
-            rows="4"
-            class="textarea textarea-primary w-full" />
-        </div>
+        <TextArea
+          headerText={$t('candidateApp.opinions.commentOnThisIssue')}
+          localStorageId={openAnswerLocal}
+          previouslySaved={translate(answer?.openAnswer)}
+          disabled={!selectedKey}
+          id="openAnswer"
+          bind:text={openAnswer}
+          bind:this={openAnswerTextArea} />
 
         {#if errorMessage}
           <p class="text-error">{errorMessage}</p>


### PR DESCRIPTION
## WHY:

Implements #212 

### What has been changed (if possible, add screenshots, gifs, etc. )

Adds a new TextArea component that can be used for open answers in the candidate app. The component features an auto save feature where changes can be saved to local storage before sending them to the database.
The component has been taken into use in the candidate questions page (open answer to a question) and the basic info page (election manifesto). This PR also fixes the candidate questions background color.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
