### PR TITLE
poc/feat: slotless page templates

### DIFF
--- a/frontend/src/routes/[[lang=locale]]/_test/+layout.svelte
+++ b/frontend/src/routes/[[lang=locale]]/_test/+layout.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import {createPageContext} from './parts/page.context';
+
+  const {containerClass} = createPageContext();
+</script>
+
+<div id="container" class={$containerClass}>
+  <div id="header-bg" />
+  <header id="logo">Logo</header>
+  <slot />
+</div>
+
+<style lang="postcss">
+  #container {
+    @apply grid min-h-screen w-full items-center justify-items-center;
+    grid-template-columns: [cols-start] auto auto [cols-end];
+    grid-template-rows: [rows-start] 5rem auto auto auto [rows-end];
+    grid-template-areas:
+      'logo header-actions'
+      'notification notification'
+      'content content'
+      'actions actions';
+  }
+
+  #logo {
+    @apply justify-self-start;
+    grid-area: logo;
+  }
+
+  #header-bg {
+    @apply self-stretch justify-self-stretch bg-base-300;
+    grid-area: 1 / cols-start / 2 / cols-end;
+  }
+</style>

--- a/frontend/src/routes/[[lang=locale]]/_test/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/_test/+page.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import {MainContent, PageConfig} from './parts';
+</script>
+
+<PageConfig containerClass="text-warning" />
+
+<MainContent>
+  <h1>Main page content</h1>
+  <p>Text should be red</p>
+  <p>
+    <a href="/_test/templates-v2-poc/subpage">Subpage</a>
+  </p>
+  <ul>
+    <li>Add another layout for cand/voter, but check if we can slot in navigation this way</li>
+    <li>Figure out main role</li>
+  </ul>
+</MainContent>

--- a/frontend/src/routes/[[lang=locale]]/_test/parts/HeaderActions.svelte
+++ b/frontend/src/routes/[[lang=locale]]/_test/parts/HeaderActions.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+</script>
+
+<div style="grid-area: header-actions" class="flex flex-row gap-x-md justify-self-end">
+  <slot />
+</div>

--- a/frontend/src/routes/[[lang=locale]]/_test/parts/MainContent.svelte
+++ b/frontend/src/routes/[[lang=locale]]/_test/parts/MainContent.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+</script>
+
+<main style="grid-area: content" class="w-full max-w-md">
+  <slot />
+</main>

--- a/frontend/src/routes/[[lang=locale]]/_test/parts/PageConfig.svelte
+++ b/frontend/src/routes/[[lang=locale]]/_test/parts/PageConfig.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import {getPageContext} from './page.context';
+
+  export let containerClass = '';
+
+  const ctx = getPageContext();
+
+  $: {
+    ctx.containerClass.set(containerClass);
+  }
+</script>

--- a/frontend/src/routes/[[lang=locale]]/_test/parts/index.ts
+++ b/frontend/src/routes/[[lang=locale]]/_test/parts/index.ts
@@ -1,0 +1,4 @@
+export {default as MainContent} from './MainContent.svelte';
+export {default as HeaderActions} from './HeaderActions.svelte';
+export {default as PageConfig} from './PageConfig.svelte';
+export * from './page.context';

--- a/frontend/src/routes/[[lang=locale]]/_test/parts/page.context.ts
+++ b/frontend/src/routes/[[lang=locale]]/_test/parts/page.context.ts
@@ -1,0 +1,17 @@
+import {getContext, setContext} from 'svelte';
+import {writable, type Writable} from 'svelte/store';
+
+const PAGE_CONTEXT_NAME = 'page-context';
+
+export type PageContext = {
+  containerClass: Writable<string>;
+};
+
+export function getPageContext(): PageContext {
+  return getContext<PageContext>(PAGE_CONTEXT_NAME);
+}
+
+export function createPageContext(): PageContext {
+  const containerClass = writable('');
+  return setContext<PageContext>(PAGE_CONTEXT_NAME, {containerClass});
+}

--- a/frontend/src/routes/[[lang=locale]]/_test/subpage/+layout.svelte
+++ b/frontend/src/routes/[[lang=locale]]/_test/subpage/+layout.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import {HeaderActions} from '../parts';
+</script>
+
+<HeaderActions>
+  <button on:click={() => console.info('foo')}>Help</button>
+</HeaderActions>
+
+<slot />

--- a/frontend/src/routes/[[lang=locale]]/_test/subpage/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/_test/subpage/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import {MainContent, PageConfig} from '../parts';
+</script>
+
+<PageConfig containerClass="" />
+
+<MainContent>
+  <h1>Subpage</h1>
+  <div id="notification">Notification</div>
+  <div id="actions"><button>Action button</button></div>
+</MainContent>
+
+<style lang="postcss">
+</style>


### PR DESCRIPTION
## WHY:

Fixes #375 

### What has been changed (if possible, add screenshots, gifs, etc. )

This PR is a PoC draft. Go to onto the `/_test` route to see the slotless layout in action. Note that it doesn't yet attempt to fully recreate the actual layouts.

Some remarks:

- The context used is just for testing and does not adhere to the future `VoterContexts` etc. (see: #573)
- Instead of a `PageConfig` component, pages could just directly access the relevant context methods.
- We might need something more involved instead of a `HeaderActions` component if we wanted to allow Svelte layouts to add items to the header that would be there on all subpages, i.e. `/foo/+layout.svelte` could add a Foo button that would be on all subpages, and `/foo/bar/+page.svelte` could add a Bar button so that both would be shown.

## Check off each of the following tasks as they are completed

- [ ] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
