### PR TITLE
fix: add email to candidate mock data generation

### DIFF
--- a/backend/vaa-strapi/src/functions/generateMockData.ts
+++ b/backend/vaa-strapi/src/functions/generateMockData.ts
@@ -383,6 +383,7 @@ async function createCandidates(length: number) {
     const firstName = faker.person.firstName();
     const lastName = faker.person.lastName();
     const party: HasId = faker.helpers.arrayElement(parties);
+    const email = `${firstName}.${lastName}@example.com`;
     // TODO: Remove these attrs later
     const politicalExperience = faker.lorem.paragraph(3);
     const motherTongue: any = faker.helpers.arrayElement(languages);
@@ -391,6 +392,7 @@ async function createCandidates(length: number) {
       data: {
         firstName,
         lastName,
+        email,
         party: party.id,
         publishedAt: new Date(),
         politicalExperience,


### PR DESCRIPTION
## WHY:

Registration was not working because mock data generation didn't add email to candidates.

### What has been changed (if possible, add screenshots, gifs, etc. )

Email was added to candidate mock data generation. It is now based on generated name of the candidate.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
