### PR TITLE
fix: locale switching with server-loaded data

### DIFF
--- a/backend/vaa-strapi/src/components/labels/action-labels.json
+++ b/backend/vaa-strapi/src/components/labels/action-labels.json
@@ -49,7 +49,7 @@
     "answerCategoryQuestions": {
       "type": "string",
       "required": true,
-      "default": "Answer {{0}} Questions"
+      "default": "Answer {numQuestions} Questions"
     },
     "readMore": {
       "type": "string",

--- a/backend/vaa-strapi/src/components/labels/view-texts.json
+++ b/backend/vaa-strapi/src/components/labels/view-texts.json
@@ -13,18 +13,18 @@
     },
     "toolDescription": {
       "type": "text",
-      "default": "With this application you can compare candidates in the elections on {{0}} based on their opinions, parties and other data.",
+      "default": "With this application you can compare candidates in the elections on {electionDate, date, ::yyyyMMdd} based on their opinions, parties and other data.",
       "required": true
     },
     "publishedBy": {
       "type": "string",
       "required": true,
-      "default": "Published by {{0}}"
+      "default": "Published by {publisher}"
     },
     "madeWith": {
       "type": "string",
       "required": true,
-      "default": "Made with {{0}}"
+      "default": "Made with "
     },
     "selectMunicipalityTitle": {
       "type": "string",
@@ -38,7 +38,7 @@
     },
     "yourConstituency": {
       "type": "string",
-      "default": "Your constituency is {{0}}",
+      "default": "Your constituency is {constituency}",
       "required": true
     },
     "yourOpinionsTitle": {
@@ -49,7 +49,7 @@
     "yourOpinionsDescription": {
       "type": "text",
       "required": true,
-      "default": "Next, the app will ask your opinions on {{0}} statements about political issues and values, which the candidates have also answered. After you've answered them, the app will find the candidates that best agree with your opinions. The statements are grouped into {{1}} categories. You can answer all of them or only select those you find important."
+      "default": "Next, the app will ask your opinions on {numStatements} statements about political issues and values, which the candidates have also answered. After you’ve answered them, the app will find the candidates that best agree with your opinions. The statements are grouped into {numCategories} categories. You can answer all of them or only select those you find important."
     },
     "questionsTip": {
       "type": "string",
@@ -62,7 +62,7 @@
     },
     "yourCandidatesDescription": {
       "type": "text",
-      "default": "These are the candidates in your constituency. The best matches are first on the list. You can also see which {{0}} best match your opinions. To narrow down the results, you can also use {{1}}.",
+      "default": "These are the candidates in your constituency. The best matches are first on the list. You can also see which {numCandidates} best match your opinions. To narrow down the results, you can also use {filters}.",
       "required": true
     },
     "yourPartiesTitle": {
@@ -72,12 +72,13 @@
     },
     "yourPartiesDescription": {
       "type": "text",
-      "default": "These are the parties in your constituency. The best matches are first on the list. You can also see which individual {{0}} best match your opinions. To narrow down the results, you can also use {{1}}.",
+      "default": "These are the parties in your constituency. The best matches are first on the list. You can also see which individual {partiesTerm} best match your opinions. To narrow down the results, you can also use {filters}.",
       "required": true
     },
     "appTitle": {
       "type": "string",
-      "default": "Election App"
+      "default": "Election App",
+      "required": true
     }
   }
 }

--- a/frontend/src/lib/components/candidates/CandidateDetailsCard.svelte
+++ b/frontend/src/lib/components/candidates/CandidateDetailsCard.svelte
@@ -16,8 +16,12 @@
   export let ranking: RankingProps | undefined = undefined;
 
   // Tabs
-  let tabs = [$t('candidate.tabs.basicInfo'), $t('candidate.tabs.opinions')];
-  let activeItem = tabs[0];
+  let tabs: string[];
+  let activeItem: string;
+  $: {
+    tabs = [$t('candidate.tabs.basicInfo'), $t('candidate.tabs.opinions')];
+    activeItem = tabs[0];
+  }
   const handleChangeTab = (e: CustomEvent) => {
     activeItem = e.detail;
   };

--- a/frontend/src/lib/components/headingGroup/HeadingGroup.svelte
+++ b/frontend/src/lib/components/headingGroup/HeadingGroup.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
   import {t} from '$lib/i18n';
-
-  $$restProps['role'] ??= 'group';
-  $$restProps['aria-roledescription'] ??= $t('aria.headingGroup');
 </script>
 
 <!--
@@ -12,11 +9,8 @@ and the main title.
 
 ### Properties
 
-- `aria-roledescription`: The Aria role description of the `<hgroup>` 
-  element representing the pre-title.
-  @default $t('aria.headingGroup')
-- `role`: The Aria role of the `<hgroup>` element.
-  @default 'group'
+- `aria-roledescription`: The Aria role description of the `<hgroup>` element representing the pre-title. @default $t('aria.headingGroup')
+- `role`: The Aria role of the `<hgroup>` element. @default 'group'
 - Any valid attributes of a `<hgroup>` element.
 
 ### Slots

--- a/frontend/src/lib/components/headingGroup/PreHeading.svelte
+++ b/frontend/src/lib/components/headingGroup/PreHeading.svelte
@@ -1,19 +1,14 @@
 <script lang="ts">
   import {t} from '$lib/i18n';
-
-  $$restProps['aria-roledescription'] ??= $t('aria.preHeading');
 </script>
 
 <!--
 @component
-Used for a pre-title, or kicker, above the main title of a page
-within a `HeadingGroup`.
+Used for a pre-title, or kicker, above the main title of a page within a `HeadingGroup`.
 
 ### Properties
 
-- `aria-roledescription`: The Aria role description of the `<p>` 
-  element representing the pre-title.
-  @default $t('aria.PreHeading')
+- `aria-roledescription`: The Aria role description of the `<p>` element representing the pre-title. @default $t('aria.PreHeading')
 - Any valid attributes of a `<p>` element.
 
 ### Slots

--- a/frontend/src/lib/i18n/init.ts
+++ b/frontend/src/lib/i18n/init.ts
@@ -5,7 +5,7 @@ import IntlMessageFormat from 'intl-messageformat';
 import {logDebugError} from '$lib/utils/logger';
 import {derived, get} from 'svelte/store';
 import {staticTranslations, type TranslationsPayload} from './translations';
-import {matchLocale} from './utils';
+import {matchLocale, purgeTranslations} from './utils';
 import settings from './settings.json';
 
 const dbLocaleProps = settings.supportedLocales;
@@ -134,7 +134,7 @@ export function addDynamicTranslations(
   translations: Parameters<typeof addTranslations>[0]
 ) {
   if (dynamicTranslationsAdded[loc]) return;
-  addTranslations({[loc]: translations});
+  addTranslations(purgeTranslations({[loc]: translations}));
   dynamicTranslationsAdded[loc] = true;
 }
 

--- a/frontend/src/lib/i18n/utils/index.ts
+++ b/frontend/src/lib/i18n/utils/index.ts
@@ -2,4 +2,5 @@ export * from './canonize';
 export * from './matchLocale';
 export * from './isLocale';
 export * from './parseAcceptedLanguages';
+export * from './purgeTranslations';
 export * from './translate';

--- a/frontend/src/lib/i18n/utils/purgeTranslations.ts
+++ b/frontend/src/lib/i18n/utils/purgeTranslations.ts
@@ -1,0 +1,23 @@
+import type {Translations} from '@sveltekit-i18n/base';
+
+/**
+ * Remove nullish values from `translations` so that they will not overwrite existing translations.
+ * @param translations A translations object tree
+ * @returns Purged translations
+ */
+export function purgeTranslations(translations: Trl): Trl {
+  if (translations == null) return undefined;
+  const merged: Trl = {};
+  for (const [k, v] of Object.entries(translations)) {
+    if (v == null) continue;
+    if (typeof v === 'object') {
+      const res = purgeTranslations(v);
+      if (res != null) merged[k] = res;
+    } else {
+      merged[k] = v;
+    }
+  }
+  return merged;
+}
+
+type Trl = Translations.SerializedTranslations | undefined;

--- a/frontend/src/lib/templates/basicPage/BasicPage.svelte
+++ b/frontend/src/lib/templates/basicPage/BasicPage.svelte
@@ -13,7 +13,7 @@
   export let title: $$Props['title'];
   export let noteClass: $$Props['noteClass'] = 'text-secondary text-center';
   export let noteRole: $$Props['noteRole'] = 'note';
-  export let primaryActionsLabel: $$Props['primaryActionsLabel'] = $t('aria.primaryActionsLabel');
+  export let primaryActionsLabel: $$Props['primaryActionsLabel'] = undefined;
 
   const authContext = getContext<AuthContext>('auth');
 
@@ -73,7 +73,7 @@ the rendering of an empty `<figure>` element even if there's no content.
 ### Properties
 
 - `title`: The required page `title`.
-- `noteClass?`: Optional class string to add to the `<div>` tag wrapping the
+- `noteClass?`: Optional class string to add to the `<div>` tag wrapping the 
   `note` slot.
 - `noteRole?`: Aria role for the `note` slot.
   @default 'note'
@@ -158,7 +158,7 @@ the rendering of an empty `<figure>` element even if there's no content.
   {#if $$slots.primaryActions}
     <section
       class="flex w-full max-w-xl flex-col items-center justify-end"
-      aria-label={primaryActionsLabel}>
+      aria-label={primaryActionsLabel ?? $t('aria.primaryActionsLabel')}>
       <slot name="primaryActions" />
     </section>
   {/if}

--- a/frontend/src/lib/templates/page/Page.svelte
+++ b/frontend/src/lib/templates/page/Page.svelte
@@ -16,14 +16,9 @@
   export let navId: $$Props['navId'] = 'pageNav';
   export let headerClass: $$Props['headerClass'] = 'bg-base-300';
   export let mainClass: $$Props['mainClass'] = '';
-  export let drawerOpenLabel: $$Props['drawerOpenLabel'] = $t('header.openMenu');
-  export let drawerCloseLabel: $$Props['drawerCloseLabel'] = $t('header.closeMenu');
-  export let drawerToggleLabel: $$Props['drawerToggleLabel'] = $t('header.toggleMenu');
-  export let skipLinkLabel: $$Props['skipLinkLabel'] = $t('aria.skipToMain');
   export let progress: $$Props['progress'] = undefined;
   export let progressMin: $$Props['progressMin'] = 0;
   export let progressMax: $$Props['progressMax'] = 100;
-  export let progressTitle: $$Props['progressTitle'] = $t('header.progressTitle');
 
   let drawerOpen = false;
   let drawerOpenElement: HTMLButtonElement | undefined;
@@ -80,25 +75,12 @@ the Drawer component.
 - `mainId?`: The id used for the `<main>` that contains the page's main content.
   This is needed for the hidden skip link at the start of the page.
   @default 'mainContent'
-- `drawerToggleId?`: The id used for the `<label>` element used by DaisyUI for toggling
-  the drawer. This must match the `for` attribute of the `<label>`
-  that's used to toggle the drawer open and closed.
-  @default 'pageDrawer'
-- `drawerCloseLabel?`: Text label for the button and overlay closing the drawer.
-  @default $t('header.closeMenu')
-- `drawerOpenLabel?`: The Aria label for the button opening the drawer.
-  @default $t('header.openMenu')
-- `drawerToggleLabel?`: The Aria label for the `<input>` that governs toggling the drawer.
-  This input is not focusable, so this is mostly theoretical.
-  @default $t('header.toggleMenu')
 - `headerClass?`: Optional class string to add to the `<header>` tag wrapping the
   `drawerOpenButton` and `header` slots.
 - `mainClass?`: Optional class string to add to the `<div>` tag wrapping the page's
   main content.
 - `navId?`: The id for the `<nav>` element containing the navigation.
   @default 'pageNav'
-- `skipLinkLabel?`: Optional text for the skip link to main content.
-  @default $t('aria.skipLinkLabel')
 - `progress?`: Optional value for the progress bar. The bar will be hidden
   if the property is `undefined` or `null`. Use the bar to show the user's
   progress in the application, not as a loading indicator: it uses the
@@ -107,8 +89,6 @@ the Drawer component.
   @default 0
 - `progressMax?`: Optional maximum value for the progress bar.
   @default 100
-- `progressTitle?`: Optional title for the progress bar.
-  @default `$t('header.progressTitle')`
 - `class`: Additional class string to append to the element's default classes.
 - Any valid attributes of a `<div>` element.
 
@@ -131,7 +111,7 @@ the Drawer component.
 </svelte:head>
 
 <!-- Skip links for screen readers and keyboard users -->
-<a href="#{mainId}" class="sr-only focus:not-sr-only">{skipLinkLabel}</a>
+<a href="#{mainId}" class="sr-only focus:not-sr-only">{$t('aria.skipToMain')}</a>
 
 <!-- Drawer container -->
 <div {...concatClass($$restProps, 'drawer')}>
@@ -144,7 +124,7 @@ the Drawer component.
     class="drawer-toggle"
     tabindex="-1"
     aria-hidden="true"
-    aria-label={drawerToggleLabel} />
+    aria-label={$t('header.toggleMenu')} />
 
   <!-- Drawer content -->
   <div class="drawer-content flex flex-col">
@@ -155,7 +135,7 @@ the Drawer component.
         bind:this={drawerOpenElement}
         aria-expanded={drawerOpen}
         aria-controls={navId}
-        aria-label={drawerOpenLabel}
+        aria-label={$t('header.openMenu')}
         class="btn btn-ghost drawer-button flex cursor-pointer items-center gap-md text-neutral">
         <slot name="drawerOpenButton">
           <Icon name="menu" />
@@ -172,7 +152,7 @@ the Drawer component.
           value={progress}
           min={progressMin}
           max={progressMax}
-          title={progressTitle}
+          title={$t('header.progressTitle')}
           class="absolute bottom-0 left-0 h-4 w-full translate-y-[50%]" />
       {/if}
     </header>
@@ -196,7 +176,7 @@ the Drawer component.
       <NavItem
         on:click={closeDrawer}
         icon="close"
-        text={drawerCloseLabel ?? 'Close'}
+        text={$t('header.closeMenu')}
         class="pt-16"
         id="drawerCloseButton" />
     </svelte:component>

--- a/frontend/src/lib/templates/page/Page.type.ts
+++ b/frontend/src/lib/templates/page/Page.type.ts
@@ -24,28 +24,6 @@ export type PageProps = SvelteHTMLElements['div'] & {
   drawerToggleId?: string | null;
 
   /**
-   * Text label for the button and overlay closing the drawer.
-   *
-   * @default $t('header.closeMenu')
-   */
-  drawerCloseLabel?: string | null;
-
-  /**
-   * The Aria label for the button opening the drawer.
-   *
-   * @default $t('header.openMenu')
-   */
-  drawerOpenLabel?: string | null;
-
-  /**
-   * The Aria label for the `<input>` that governs toggling the drawer.
-   * This input is not focusable, so this is mostly theoretical.
-   *
-   * @default $t('header.toggleMenu')
-   */
-  drawerToggleLabel?: string | null;
-
-  /**
    * Optional class string to add to the `<header>` tag wrapping the
    * `drawerOpenButton` and `header` slots.
    */
@@ -63,13 +41,6 @@ export type PageProps = SvelteHTMLElements['div'] & {
    * @default 'pageNav'
    */
   navId?: string | null;
-
-  /**
-   * Optional text for the skip link to main content.
-   *
-   * @default $t('aria.skipLinkLabel')
-   */
-  skipLinkLabel?: string | null;
 
   /**
    * Optional value for the progress bar. The bar will be hidden
@@ -92,11 +63,4 @@ export type PageProps = SvelteHTMLElements['div'] & {
    * @default 100
    */
   progressMax?: number | null;
-
-  /**
-   * Optional title for the progress bar.
-   *
-   * @default `$t('header.progressTitle')`
-   */
-  progressTitle?: string | null;
 };

--- a/frontend/src/routes/[[lang=locale]]/(voters)/candidates/+layout.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/candidates/+layout.server.ts
@@ -1,10 +1,11 @@
 import {getOpinionQuestions, getInfoQuestions} from '$lib/api/getData';
 import type {LayoutServerLoad} from './$types';
 
-export const load = (async () => {
+export const load = (async ({parent}) => {
+  const locale = (await parent()).i18n.currentLocale;
   return {
     // We need these for displaying the candidates
-    questions: await getOpinionQuestions(),
-    infoQuestions: await getInfoQuestions()
+    questions: await getOpinionQuestions({locale}),
+    infoQuestions: await getInfoQuestions({locale})
   };
 }) satisfies LayoutServerLoad;

--- a/frontend/src/routes/[[lang=locale]]/(voters)/candidates/+page.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/candidates/+page.server.ts
@@ -1,8 +1,9 @@
 import {getNominatedCandidates} from '$lib/api/getData';
 import type {PageServerLoad} from './$types';
 
-export const load = (async () => {
+export const load = (async ({parent}) => {
+  const locale = (await parent()).i18n.currentLocale;
   return {
-    candidates: await getNominatedCandidates()
+    candidates: await getNominatedCandidates({locale})
   };
 }) satisfies PageServerLoad;

--- a/frontend/src/routes/[[lang=locale]]/(voters)/candidates/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/candidates/+page.svelte
@@ -9,6 +9,9 @@
   import type {PageServerData} from './$types';
 
   export let data: PageServerData;
+
+  let candidates: CandidateProps[];
+  $: candidates = data.candidates;
 </script>
 
 <BasicPage title={$t('candidates.candidates')} mainClass="bg-base-300">
@@ -38,7 +41,7 @@
     role="feed"
     class="-mx-md grid w-[calc(100%+20rem/16)] grid-cols-1 gap-md match-w-xl:mx-0 match-w-xl:w-full"
     aria-label={$t('candidates.candidates')}>
-    {#each data.candidates as { id, firstName, lastName, party, electionSymbol }, i}
+    {#each candidates as { id, firstName, lastName, party, electionSymbol }, i}
       <EntityCard
         on:click={() => goto($getRoute({route: Route.Candidate, id}))}
         ariaPosinset={i + 1}

--- a/frontend/src/routes/[[lang=locale]]/(voters)/candidates/[candidateId]/+page.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/candidates/[candidateId]/+page.server.ts
@@ -2,9 +2,10 @@ import {getNominatedCandidates} from '$lib/api/getData';
 import {error} from '@sveltejs/kit';
 import type {PageServerLoad} from './$types';
 
-export const load = (async ({params}) => {
+export const load = (async ({parent, params}) => {
+  const locale = (await parent()).i18n.currentLocale;
   const id = params.candidateId;
-  const results = await getNominatedCandidates({id, loadAnswers: true});
+  const results = await getNominatedCandidates({id, loadAnswers: true, locale});
   if (results.length === 0) {
     throw error(404, 'Candidate not found');
   }

--- a/frontend/src/routes/[[lang=locale]]/(voters)/candidates/[candidateId]/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/candidates/[candidateId]/+page.svelte
@@ -10,7 +10,14 @@
 
   export let data: PageServerData & LayoutServerData;
 
-  const {candidate, questions, infoQuestions} = data;
+  let candidate: CandidateProps;
+  let questions: QuestionProps[];
+  let infoQuestions: QuestionProps[];
+  $: {
+    candidate = data.candidate;
+    questions = data.questions;
+    infoQuestions = data.infoQuestions;
+  }
 </script>
 
 <SingleCardPage title={GetFullNameInOrder(candidate.firstName, candidate.lastName)}>

--- a/frontend/src/routes/[[lang=locale]]/(voters)/intro/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/intro/+page.svelte
@@ -5,18 +5,16 @@
   import {HeadingGroup, PreHeading} from '$lib/components/headingGroup';
   import {HeroEmoji} from '$lib/components/heroEmoji';
   import {BasicPage} from '$lib/templates/basicPage';
-
-  const title = $t('intro.title');
 </script>
 
-<BasicPage {title}>
+<BasicPage title={$t('intro.title')}>
   <svelte:fragment slot="hero">
     <HeroEmoji emoji={$t('intro.heroEmoji')} />
   </svelte:fragment>
 
   <HeadingGroup slot="heading">
     <PreHeading class="text-primary">{$t('viewTexts.appTitle')}</PreHeading>
-    <h1>{title}</h1>
+    <h1>{$t('intro.title')}</h1>
   </HeadingGroup>
 
   <svelte:fragment slot="banner">

--- a/frontend/src/routes/[[lang=locale]]/(voters)/parties/+page.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/parties/+page.server.ts
@@ -1,8 +1,9 @@
 import {getNominatingParties} from '$lib/api/getData';
 import type {PageServerLoad} from './$types';
 
-export const load = (async () => {
+export const load = (async ({parent}) => {
+  const locale = (await parent()).i18n.currentLocale;
   return {
-    parties: await getNominatingParties()
+    parties: await getNominatingParties({locale})
   };
 }) satisfies PageServerLoad;

--- a/frontend/src/routes/[[lang=locale]]/(voters)/parties/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/parties/+page.svelte
@@ -8,6 +8,9 @@
   import type {PageServerData} from './$types';
 
   export let data: PageServerData;
+
+  let parties: PartyProps[];
+  $: parties = data.parties;
 </script>
 
 <BasicPage title={$t('parties.parties')} mainClass="bg-base-300">
@@ -32,7 +35,7 @@
     role="feed"
     class="-mx-md grid w-[calc(100%+20rem/16)] grid-cols-1 gap-md match-w-xl:mx-0 match-w-xl:w-full"
     aria-label={$t('parties.parties')}>
-    {#each data.parties as { id, name, shortName }, i}
+    {#each parties as { id, name, shortName }, i}
       <EntityCard
         on:click={() => goto($getRoute({route: Route.Party, id}))}
         ariaPosinset={i + 1}

--- a/frontend/src/routes/[[lang=locale]]/(voters)/parties/[partyId]/+page.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/parties/[partyId]/+page.server.ts
@@ -2,13 +2,14 @@ import {getNominatedCandidates, getNominatingParties} from '$lib/api/getData';
 import {error} from '@sveltejs/kit';
 import type {PageServerLoad} from './$types';
 
-export const load = (async ({params}) => {
+export const load = (async ({params, parent}) => {
+  const locale = (await parent()).i18n.currentLocale;
   const id = params.partyId;
   if (!id) {
     throw error(404, 'Invalid party id');
   }
-  const candidates = await getNominatedCandidates({nominatingPartyId: id});
-  const results = await getNominatingParties({id, loadAnswers: true});
+  const candidates = await getNominatedCandidates({nominatingPartyId: id, locale});
+  const results = await getNominatingParties({id, loadAnswers: true, locale});
   if (results.length === 0) {
     throw error(404, 'Party not found');
   }

--- a/frontend/src/routes/[[lang=locale]]/(voters)/parties/[partyId]/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/parties/[partyId]/+page.svelte
@@ -8,7 +8,8 @@
 
   export let data: PageServerData;
 
-  const {party} = data;
+  let party: PartyProps;
+  $: party = data.party;
 </script>
 
 <SingleCardPage title={party.name}>

--- a/frontend/src/routes/[[lang=locale]]/(voters)/questions/+layout.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/questions/+layout.server.ts
@@ -1,8 +1,9 @@
 import type {LayoutServerLoad} from './$types';
 import {getOpinionQuestions} from '$lib/api/getData';
 
-export const load = (async () => {
+export const load = (async ({parent}) => {
+  const locale = (await parent()).i18n.currentLocale;
   return {
-    questions: await getOpinionQuestions()
+    questions: await getOpinionQuestions({locale})
   };
 }) satisfies LayoutServerLoad;

--- a/frontend/src/routes/[[lang=locale]]/(voters)/questions/+layout.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/questions/+layout.svelte
@@ -3,13 +3,16 @@
   import type {LayoutServerData} from './$types';
 
   export let data: LayoutServerData;
+
+  let questions: QuestionProps[];
+  $: questions = data.questions;
 </script>
 
 <svelte:head>
   <title>{$t('questions.questionsTitle')}</title>
 </svelte:head>
 
-{#if !data.questions.length}
+{#if !questions?.length}
   <p>{$t('error.noQuestions')}</p>
 {:else}
   <slot />

--- a/frontend/src/routes/[[lang=locale]]/(voters)/questions/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/questions/+page.svelte
@@ -7,16 +7,9 @@
   import {Icon} from '$lib/components/icon';
   import {BasicPage} from '$lib/templates/basicPage';
 
-  const firstQuestionUrl = $getRoute({route: Route.Question, id: $page.data.questions[0].id});
-
   const questionCategories = new Set<string>();
   $page.data.questions.forEach((question) => {
     if (question.category) questionCategories.add(question.category);
-  });
-
-  const opinionsDescriptionText = $t('viewTexts.yourOpinionsDescription', {
-    numStatements: $page.data.questions.length,
-    numCategories: questionCategories.size
   });
 </script>
 
@@ -39,12 +32,15 @@
   </svelte:fragment>
 
   <p class="text-center">
-    {opinionsDescriptionText}
+    {$t('viewTexts.yourOpinionsDescription', {
+      numStatements: $page.data.questions.length,
+      numCategories: questionCategories.size
+    })}
   </p>
 
   <svelte:fragment slot="primaryActions">
     <Button
-      href={firstQuestionUrl}
+      href={$getRoute({route: Route.Question, id: $page.data.questions[0].id})}
       variant="main"
       icon="next"
       text={$t('actionLabels.startQuestions')} />

--- a/frontend/src/routes/[[lang=locale]]/(voters)/questions/[questionId]/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/questions/[questionId]/+page.svelte
@@ -24,16 +24,15 @@
    */
   const DELAY_M_MS = 350;
 
-  const {questions} = data;
-
+  let questions: QuestionProps[];
   let questionId: string;
   let question: QuestionProps | undefined;
   let questionIndex: number;
   let selectedKey: AnswerOption['key'] | undefined;
 
-  // Set questionId reactively when the route param changes, but only
-  // if the id is different so that we don't trigger unnecessary re-renders
-  $: if (questionId != data.questionId) {
+  // Set questionId reactively when the route param changes
+  $: {
+    questions = data.questions;
     questionId = data.questionId;
     question = questions.find((q) => q.id == questionId);
     if (!question) throw error(404, `No question with id ${questionId}`);

--- a/frontend/src/routes/[[lang=locale]]/(voters)/results/+layout.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/results/+layout.server.ts
@@ -1,11 +1,12 @@
 import {getInfoQuestions, getNominatedCandidates, getOpinionQuestions} from '$lib/api/getData';
 import type {LayoutServerLoad} from './$types';
 
-export const load = (async () => {
+export const load = (async ({parent}) => {
+  const locale = (await parent()).i18n.currentLocale;
   return {
-    candidates: await getNominatedCandidates({loadAnswers: true}),
+    candidates: await getNominatedCandidates({loadAnswers: true, locale}),
     // We need these for displaying the candidates
-    questions: await getOpinionQuestions(),
-    infoQuestions: await getInfoQuestions()
+    questions: await getOpinionQuestions({locale}),
+    infoQuestions: await getInfoQuestions({locale})
   };
 }) satisfies LayoutServerLoad;

--- a/frontend/src/routes/[[lang=locale]]/(voters)/results/+layout.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/results/+layout.svelte
@@ -3,9 +3,12 @@
   import type {LayoutServerData} from './$types';
 
   export let data: LayoutServerData;
+
+  let candidates: CandidateProps[];
+  $: candidates = data.candidates;
 </script>
 
-{#if !data.candidates.length}
+{#if !candidates?.length}
   <p>{$t('candidates.notFound')}</p>
 {:else}
   <slot />

--- a/frontend/src/routes/[[lang=locale]]/(voters)/results/[candidateId]/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/results/[candidateId]/+page.svelte
@@ -10,31 +10,41 @@
 
   export let data: PageData;
 
-  const {candidateId, candidates, questions, infoQuestions} = data;
-
+  let candidateId: string;
+  let candidates: CandidateProps[];
+  let questions: QuestionProps[];
+  let infoQuestions: QuestionProps[];
   let candidate: CandidateProps | undefined;
   let ranking: RankingProps | undefined;
+  let title = '';
 
-  // First, check if we have a ranking for the candidate,
-  // which contains the Candidate object
-  // TODO: We could disallow access to this page if there are no
-  // $candidateRankings by moving the redirect check currently in
-  // ../+page.svelte to ../+layout.svelte
-  if ($candidateRankings.length > 0) {
-    const result = $candidateRankings.find((r) => r.candidate.id == candidateId);
-    if (result) {
-      candidate = result.candidate;
-      ranking = result.match;
+  $: {
+    candidateId = data.candidateId;
+    candidates = data.candidates;
+    questions = data.questions;
+    infoQuestions = data.infoQuestions;
+
+    // First, check if we have a ranking for the candidate,
+    // which contains the Candidate object
+    // TODO: We could disallow access to this page if there are no
+    // $candidateRankings by moving the redirect check currently in
+    // ../+page.svelte to ../+layout.svelte
+    if ($candidateRankings.length > 0) {
+      const result = $candidateRankings.find((r) => r.candidate.id == candidateId);
+      if (result) {
+        candidate = result.candidate;
+        ranking = result.match;
+      }
     }
-  }
-  // If not, try to find the candidate
-  if (!candidate) {
-    candidate = candidates.find((c) => c.id == candidateId);
-  }
+    // If not, try to find the candidate
+    if (!candidate) {
+      candidate = candidates.find((c) => c.id == candidateId);
+    }
 
-  const title = candidate
-    ? GetFullNameInOrder(candidate.firstName, candidate.lastName)
-    : $t('candidates.notFound');
+    title = candidate
+      ? GetFullNameInOrder(candidate.firstName, candidate.lastName)
+      : $t('candidates.notFound');
+  }
 </script>
 
 <SingleCardPage {title}>

--- a/frontend/src/routes/[[lang=locale]]/+layout.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/+layout.server.ts
@@ -1,14 +1,14 @@
 import type {LayoutServerLoad} from './$types';
 import {error} from '@sveltejs/kit';
 import {getElection} from '$lib/api/getData';
-import {loadTranslations, setLocale} from '$lib/i18n';
+import {loadTranslations, locale} from '$lib/i18n';
 
 export const load = (async ({locals}) => {
   // Get language from locals (see hooks.server.ts)
   const {currentLocale, preferredLocale, route} = locals;
 
   // Set the locale so that getData can used it as default
-  setLocale(currentLocale);
+  if (currentLocale !== locale.get()) locale.set(currentLocale);
 
   // Get basic data and translations
   const election = await getElection({locale: currentLocale});

--- a/frontend/src/routes/[[lang=locale]]/+layout.svelte
+++ b/frontend/src/routes/[[lang=locale]]/+layout.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import {t} from '$lib/i18n';
   import '../../app.css';
+  import type {LayoutData} from './$types';
+
+  export let data: LayoutData;
 </script>
 
 <svelte:head>
   <title>{$t('viewTexts.appTitle')}</title>
 </svelte:head>
 
-<slot />
+{#if data.election}
+  <slot />
+{:else}
+  <span class="loading loading-spinner loading-lg" />
+{/if}

--- a/frontend/src/routes/[[lang=locale]]/+layout.svelte
+++ b/frontend/src/routes/[[lang=locale]]/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {t, locale} from '$lib/i18n';
+  import {t} from '$lib/i18n';
   import '../../app.css';
 </script>
 
@@ -7,7 +7,4 @@
   <title>{$t('viewTexts.appTitle')}</title>
 </svelte:head>
 
-<!-- The $locale key is necessary for locale changes to be reflected to updates in localised content (although any content using the $t will be updated automatically) -->
-{#key $locale}
-  <slot />
-{/key}
+<slot />


### PR DESCRIPTION
## WHY:

Fixes #420 

### What has been changed (if possible, add screenshots, gifs, etc. )

Fixes localised text updates when the localised data is part of server-loaded data, including `App Labels`.

Server `load` functions now depend on either the `lang` route param or the outermost layout's `data.i18n.currentLocale`, which is awaited for using `parent()`.

When data is loaded on the server and updated due to locale changes, components using it are not automatically rerendered by the client. This update makes all such data reactive in the frontend.

NB. The subobjects of `data` used are now made explicit, but a more concise way would be to remove `export let data` altogether and always call `$page.data.foo` to get the requisite data.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
