### PR TITLE
Feature:Made logout modal's text dynamically tell actual amount of op…

### DIFF
--- a/frontend/src/lib/candidate/components/logoutButton/LogoutButton.svelte
+++ b/frontend/src/lib/candidate/components/logoutButton/LogoutButton.svelte
@@ -20,7 +20,6 @@
   let timeLeft = logoutModalTimer;
 
   // functions for logout button
-  // TODO: add proper check of unfilled data
   const answerContext = getContext<AnswerContext | undefined>('answers');
   const answerstoreWritable = answerContext?.answers;
   $: answerStore = $answerstoreWritable;
@@ -48,7 +47,6 @@
   $: unfilledData = remainingOpinionNumber > 0 || remainingInfoAmount > 0;
 
   const triggerLogout = () => {
-    // TODO: check if candidate has filled all the data
     if (unfilledData) {
       openModal();
     } else {

--- a/frontend/src/lib/candidate/components/logoutButton/LogoutButton.svelte
+++ b/frontend/src/lib/candidate/components/logoutButton/LogoutButton.svelte
@@ -100,9 +100,19 @@ When set to false, the button variant is main.
   <div class="notification max-w-md text-center">
     <h2>{$t('candidateApp.logoutModal.title')}</h2>
     <br />
-    <p>
-      {$t('candidateApp.logoutModal.body', {remainingInfoAmount, remainingOpinionNumber})}
-    </p>
+    {#if remainingInfoAmount > 0}
+      <p>
+        {$t('candidateApp.logoutModal.body', {remainingInfoAmount, remainingOpinionNumber})}
+      </p>
+    {:else if remainingOpinionNumber > 1}
+      <p>
+        {$t('candidateApp.logoutModal.bodyBasicInfoReady', {remainingOpinionNumber})}
+      </p>
+    {:else}
+      <p>
+        {$t('candidateApp.logoutModal.bodyBasicInfoReady1OpinionLeft')}
+      </p>
+    {/if}
     <p>
       {$t('candidateApp.logoutModal.confirmation', {timeLeft})}
     </p>

--- a/frontend/src/lib/i18n/translations/en/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/en/candidateApp.json
@@ -20,7 +20,7 @@
   },
   "logoutModal": {
     "title": "Some of Your Data Is Still Missing",
-    "body": "There are still 10 items of basic info and 25 opinions to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
+    "body": "There are still {remainingInfoAmount} items of basic info and {remainingOpinionNumber} opinions to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
     "confirmation": "Are you sure you want to logout? You will be automatically logged out after {timeLeft} seconds.",
     "continueEnteringData": "Continue Entering Data"
   },

--- a/frontend/src/lib/i18n/translations/en/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/en/candidateApp.json
@@ -21,6 +21,8 @@
   "logoutModal": {
     "title": "Some of Your Data Is Still Missing",
     "body": "There are still {remainingInfoAmount} items of basic info and {remainingOpinionNumber} opinions to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
+    "bodyBasicInfoReady": "There are still {remainingOpinionNumber} opinions to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
+    "bodyBasicInfoReady1OpinionLeft": "There is still 1 opinion to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
     "confirmation": "Are you sure you want to logout? You will be automatically logged out after {timeLeft} seconds.",
     "continueEnteringData": "Continue Entering Data"
   },

--- a/frontend/src/lib/i18n/translations/fi/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/fi/candidateApp.json
@@ -20,7 +20,7 @@
   },
   "logoutModal": {
     "title": "Osa tiedoistasi puuttuu edelleen",
-    "body": "Täytettävänä on vielä 10 perustietoa ja 25 mielipidettä. Tietosi eivät näy Vaalikompassissa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
+    "body": "Täytettävänä on vielä {remainingInfoAmount} perustietoa ja {remainingOpinionNumber} mielipidettä. Tietosi eivät näy Vaalikompassissa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
     "confirmation": "Oletko varma, että haluat kirjautua ulos? Sinut kirjaudutaan automaattisesti ulos {timeLeft} sekunnin kuluttua.",
     "continueEnteringData": "Jatka tietojen syöttämistä"
   },

--- a/frontend/src/lib/i18n/translations/fi/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/fi/candidateApp.json
@@ -21,6 +21,8 @@
   "logoutModal": {
     "title": "Osa tiedoistasi puuttuu edelleen",
     "body": "Täytettävänä on vielä {remainingInfoAmount} perustietoa ja {remainingOpinionNumber} mielipidettä. Tietosi eivät näy Vaalikompassissa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
+    "bodyBasicInfoReady": "Täytettävänä on vielä {remainingOpinionNumber} mielipidettä. Tietosi eivät näy Vaalikompassissa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
+    "bodyBasicInfoReady1OpinionLeft": "Täytettävänä on vielä yksi mielipide. Tietosi eivät näy Vaalikompassissa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
     "confirmation": "Oletko varma, että haluat kirjautua ulos? Sinut kirjaudutaan automaattisesti ulos {timeLeft} sekunnin kuluttua.",
     "continueEnteringData": "Jatka tietojen syöttämistä"
   },


### PR DESCRIPTION
…inions and basic information left

## WHY:
Makes logout modal's message dynamically tell user how many opinions and basic information they have not filled

### What has been changed (if possible, add screenshots, gifs, etc. )

![image](https://github.com/OpenVAA/voting-advice-application/assets/122307901/acf916de-4d31-4efb-9a46-96c16ae20c73)

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [x] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
