### PR TITLE
feat: info note on candidate app preview

### DIFF
--- a/frontend/src/lib/i18n/translations/en/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/en/candidateApp.json
@@ -154,6 +154,7 @@
   },
   "preview": {
     "title": "Preview",
-    "notFound": "Profile not found"
+    "notFound": "Profile not found",
+    "tip": "This is a preview of how your profile will look to voters."
   }
 }

--- a/frontend/src/lib/i18n/translations/fi/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/fi/candidateApp.json
@@ -154,6 +154,7 @@
   },
   "preview": {
     "title": "Profiilin esikatselu",
-    "notFound": "Profiilia ei löytynyt"
+    "notFound": "Profiilia ei löytynyt",
+    "tip": "Tämä on esikatselu siitä, miltä profiilisi näyttää äänestäjille."
   }
 }

--- a/frontend/src/lib/templates/singleCardPage/SingleCardPage.svelte
+++ b/frontend/src/lib/templates/singleCardPage/SingleCardPage.svelte
@@ -6,6 +6,8 @@
   type $$Props = SingleCardPageProps;
 
   export let cardClass: $$Props['cardClass'] = '';
+  export let noteClass: $$Props['noteClass'] = '-mt-md mb-xl text-secondary text-center';
+  export let noteRole: $$Props['noteRole'] = 'note';
 
   // We need this explicit typing to get rid of linter errors below
   function _concatClass(props: SvelteRestProps, classes: string) {
@@ -19,25 +21,22 @@ A template for pages that show just a single card, such as a single candidate.
 
 The content is provided in the default slot with some optional named slots.
 
-Use the properties to add to the classes of the elements containing the slots,
-to define some ids, pass Aria labels and show an optional progress bar in the
-header. You can also pass any valid properties of the `<Page>` template this
-is based on.
+Use the properties to add to the classes of the elements containing the slots, to define some ids, pass Aria labels and show an optional progress bar in the header. You can also pass any valid properties of the `<Page>` template this is based on.
 
 ### Slots
 
 - default: the card that's the main content of the page
+- `banner`: content for the secondary actions displayed on the right side of the `<header>`
 - `banner`: content for the secondary actions displayed on the right
-  side of the `<header>`
-
 
 ### Properties
 
 - `title`: The required page `title`.
-- `cardClass?`: Optional class string to add to the `<div>` tag that defines the
-  card wrapping the `default` slot.
+- `cardClass?`: Optional class string to add to the `<div>` tag that defines the card wrapping the `default` slot.
+- `noteClass?`: Optional class string to add to the `<div>` tag wrapping the `note` slot.
+- `noteRole?`: Aria role for the `note` slot. @default `'note'`
 - `class`: Additional class string to append to the element's default classes.
-- Any valid properties of the `Page` template.
+- Any valid properties of the `<Page>` template.
 
 
 ### Usage
@@ -49,6 +48,8 @@ is based on.
       <Button on:click={addToList} variant="icon" icon="addToList" title="Add to list"/>
     </svelte:fragment>
 
+    <span slot="note" class="text-warning">Warning!</span>
+
     <CandidateDetailsCard {candidate} />
         
   </SingleCardPage>
@@ -58,6 +59,13 @@ is based on.
 <Page {..._concatClass($$restProps, 'bg-base-300')}>
   <!-- Header -->
   <slot name="banner" slot="banner" />
+
+  <!-- Note -->
+  {#if $$slots.note}
+    <div class={noteClass} role={noteRole}>
+      <slot name="note" />
+    </div>
+  {/if}
 
   <!-- The card -->
   <div

--- a/frontend/src/lib/templates/singleCardPage/SingleCardPage.type.ts
+++ b/frontend/src/lib/templates/singleCardPage/SingleCardPage.type.ts
@@ -1,9 +1,17 @@
+import type {AriaRole} from 'svelte/elements';
 import type {PageProps} from '../page';
 
 export interface SingleCardPageProps extends PageProps {
   /**
-   * Optional class string to add to the `<div>` tag that defines the
-   * card wrapping the `default` slot.
+   * Optional class string to add to the `<div>` tag that defines the card wrapping the `default` slot.
    */
   cardClass?: string;
+  /**
+   * Optional class string to add to the `<div>` tag wrapping the `note` slot.
+   */
+  noteClass?: string;
+  /**
+   * Aria role for the `note` slot. @default 'note'
+   */
+  noteRole?: AriaRole;
 }

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.server.ts
@@ -1,11 +1,12 @@
 import {getOpinionQuestions, getInfoQuestions, getNominatedCandidates} from '$lib/api/getData';
-import type {LayoutServerLoad} from '../../../$types';
+import type {PageServerLoad} from './$types';
 
-export const load = (async () => {
+export const load = (async ({parent}) => {
+  const locale = (await parent()).i18n.currentLocale;
   // TODO: Get candidate data on the client side using the id in AuthContext
   return {
-    opinionQuestions: await getOpinionQuestions(),
-    infoQuestions: await getInfoQuestions(),
-    candidates: await getNominatedCandidates({loadAnswers: true})
+    opinionQuestions: await getOpinionQuestions({locale}),
+    infoQuestions: await getInfoQuestions({locale}),
+    candidates: await getNominatedCandidates({loadAnswers: true, locale})
   };
-}) satisfies LayoutServerLoad;
+}) satisfies PageServerLoad;

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import {t} from '$lib/i18n';
-  import {CandidateDetailsCard} from '$lib/components/candidates';
-  import SingleCardPage from '$lib/templates/singleCardPage/SingleCardPage.svelte';
   import {getContext} from 'svelte';
+  import {t} from '$lib/i18n';
   import type {AuthContext} from '$lib/utils/authenticationStore';
+  import {CandidateDetailsCard} from '$lib/components/candidates';
+  import {Icon} from '$lib/components/icon';
+  import SingleCardPage from '$lib/templates/singleCardPage/SingleCardPage.svelte';
   import LogoutButton from '$lib/candidate/components/logoutButton/LogoutButton.svelte';
   import type {PageData} from './$types';
 
@@ -28,6 +29,10 @@
   <span>{$t('candidateApp.preview.notFound')}</span>
 {:else}
   <SingleCardPage title={$t('candidateApp.preview.title')}>
+    <svelte:fragment slot="note">
+      <Icon name="info" />
+      {$t('candidateApp.preview.tip')}
+    </svelte:fragment>
     <LogoutButton slot="banner" />
     <CandidateDetailsCard {candidate} {opinionQuestions} {infoQuestions} />
   </SingleCardPage>

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
@@ -5,18 +5,23 @@
   import {getContext} from 'svelte';
   import type {AuthContext} from '$lib/utils/authenticationStore';
   import LogoutButton from '$lib/candidate/components/logoutButton/LogoutButton.svelte';
+  import type {PageData} from './$types';
 
-  export let data: {
-    infoQuestions: QuestionProps[];
-    opinionQuestions: QuestionProps[];
-    candidates: CandidateProps[];
-  };
+  export let data: PageData;
 
-  const {opinionQuestions, infoQuestions, candidates} = data;
   const {user} = getContext<AuthContext>('auth');
-  const candidate = candidates.find(
-    (c: CandidateProps) => c.id === $user?.candidate?.id.toString()
-  );
+
+  let infoQuestions: QuestionProps[];
+  let opinionQuestions: QuestionProps[];
+  let candidates: CandidateProps[];
+  let candidate: CandidateProps | undefined;
+
+  $: {
+    infoQuestions = data.infoQuestions;
+    opinionQuestions = data.opinionQuestions;
+    candidates = data.candidates;
+    candidate = candidates.find((c) => c.id === `${$user?.candidate?.id}`);
+  }
 </script>
 
 {#if !candidate}

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/+layout.server.ts
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/+layout.server.ts
@@ -1,8 +1,9 @@
-import type {LayoutServerLoad} from '$types';
-import {getQuestions} from '$lib/api/getData';
+import type {LayoutServerLoad} from './$types';
+import {getOpinionQuestions} from '$lib/api/getData';
 
-export const load = (async () => {
+export const load = (async ({parent}) => {
+  const locale = (await parent()).i18n.currentLocale;
   return {
-    questions: await getQuestions()
+    questions: await getOpinionQuestions({locale})
   };
 }) satisfies LayoutServerLoad;

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/summary/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/summary/+page.svelte
@@ -11,13 +11,16 @@
   import {translate} from '$lib/i18n/utils/translate';
   import QuestionOpenAnswer from '$lib/components/questions/QuestionOpenAnswer.svelte';
 
-  const questions = $page.data.questions;
-
   const store = answerContext.answers;
   $: answerStore = $store;
 
-  const questionsByCategory = questions.reduce(
-    (acc: Record<string, Array<QuestionProps>>, question) => {
+  let questions: QuestionProps[];
+  let questionsByCategory: Record<string, Array<QuestionProps>>;
+
+  $: questions = $page.data.questions;
+
+  $: questionsByCategory = questions.reduce(
+    (acc, question) => {
       if (!question.category) {
         return acc;
       }
@@ -27,7 +30,7 @@
       acc[question.category].push(question);
       return acc;
     },
-    {}
+    {} as typeof questionsByCategory
   );
 
   let nofUnansweredQuestions = 0;


### PR DESCRIPTION
## WHY:

Fixes feedback received from users

### What has been changed (if possible, add screenshots, gifs, etc. )

Adds a note explaining what the preview of a candidate's profile is.

This requires also adding a similar `note` slot to `SingleCardPage` as on `BasicPage` for displaying notifications.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
