### PR TITLE
Feat/202 select UI language

### DIFF
--- a/backend/vaa-strapi/src/api/candidate/content-types/candidate/schema.json
+++ b/backend/vaa-strapi/src/api/candidate/content-types/candidate/schema.json
@@ -106,6 +106,11 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::gender.gender"
+    },
+    "appLanguage": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::language.language"
     }
   }
 }

--- a/backend/vaa-strapi/src/api/candidate/routes/candidate.ts
+++ b/backend/vaa-strapi/src/api/candidate/routes/candidate.ts
@@ -44,7 +44,7 @@ export default factories.createCoreRouter('api::candidate.candidate', {
         // Disable filters by default to avoid accidentally leaking data of relations
         restrictFilters([]),
         // Allow only updating the following fields
-        restrictBody(['gender', 'birthday', 'unaffiliated', 'photo', 'manifesto', 'motherTongues', 'otherLanguages', 'politicalExperience']),
+        restrictBody(['gender', 'birthday', 'unaffiliated', 'photo', 'manifesto', 'motherTongues', 'otherLanguages', 'politicalExperience', 'appLanguage']),
       ],
     },
   },

--- a/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
+++ b/backend/vaa-strapi/src/extensions/users-permissions/strapi-server.js
@@ -131,7 +131,8 @@ module.exports = async (plugin) => {
         'candidate.populate.party',
         'candidate.populate.photo',
         'candidate.populate.motherTongues',
-        'candidate.populate.gender'
+        'candidate.populate.gender',
+        'candidate.populate.appLanguage'
       ]),
       // Disable filters by default to avoid accidentally leaking data of relations
       restrictFilters([])

--- a/frontend/src/lib/api/candidate.ts
+++ b/frontend/src/lib/api/candidate.ts
@@ -134,7 +134,7 @@ export const updateBasicInfo = async (
 /**
  * Change the user's preferred language for the app.
  */
-export const updateAppLanguage = async (language?: Language) => {
+export const updateAppLanguage = async (language: Language) => {
   const user = get(candidateContext.userStore);
   const candidate = user?.candidate;
 

--- a/frontend/src/lib/api/candidate.ts
+++ b/frontend/src/lib/api/candidate.ts
@@ -85,7 +85,8 @@ export const me = async (): Promise<User | undefined> => {
       'populate[candidate][populate][party]': 'true',
       'populate[candidate][populate][photo]': 'true',
       'populate[candidate][populate][gender]': 'true',
-      'populate[candidate][populate][motherTongues]': 'true'
+      'populate[candidate][populate][motherTongues]': 'true',
+      'populate[candidate][populate][appLanguage]': 'true'
     })
   );
 
@@ -122,6 +123,30 @@ export const updateBasicInfo = async (
         unaffiliated,
         photo: photo?.id,
         motherTongues
+      }
+    }),
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+};
+
+/**
+ * Change the user's preferred language for the app.
+ */
+export const updateAppLanguage = async (language?: Language) => {
+  const user = get(candidateContext.userStore);
+  const candidate = user?.candidate;
+
+  if (!candidate) {
+    throw new Error('user.candidate is undefined');
+  }
+
+  return await request(getUrl(`api/candidates/${candidate.id}`), {
+    method: 'PUT',
+    body: JSON.stringify({
+      data: {
+        appLanguage: language?.id
       }
     }),
     headers: {

--- a/frontend/src/lib/candidate/templates/login/LoginPage.svelte
+++ b/frontend/src/lib/candidate/templates/login/LoginPage.svelte
@@ -2,6 +2,7 @@
   import {getContext} from 'svelte';
   import {page} from '$app/stores';
   import {t} from '$lib/i18n';
+  import {goto} from '$app/navigation';
   import {getRoute, Route} from '$lib/utils/navigation';
   import {Button} from '$lib/components/button';
   import {HeadingGroup, PreHeading} from '$lib/components/headingGroup';
@@ -10,16 +11,28 @@
   import {FrontPage} from '$lib/templates/frontPage';
   import type {CandidateContext} from '$lib/utils/candidateStore';
 
-  const {logIn, emailOfNewUserStore} = getContext<CandidateContext>('candidate');
+  const {userStore, logIn, emailOfNewUserStore} = getContext<CandidateContext>('candidate');
 
   let email = '';
   let password = '';
   let wrongCredentials = false;
+
+  // Variable for the user's chosen app language
+  let appLanguageCode: string;
+  userStore.subscribe((user) => {
+    appLanguageCode = user?.candidate?.appLanguage?.localisationCode;
+  });
+
   const onLogin = async () => {
     if (!(await logIn(email, password))) {
       wrongCredentials = true;
     } else {
       emailOfNewUserStore.set(null);
+
+      // If user has chosen an app language, change to that language
+      if (appLanguageCode) {
+        await goto($getRoute({locale: appLanguageCode}));
+      }
     }
   };
   if ($emailOfNewUserStore != null) {

--- a/frontend/src/lib/i18n/translations/en/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/en/candidateApp.json
@@ -61,6 +61,7 @@
     },
     "emailDescription": "We use this email to connect to you and for password reset. It will not be shown on your public profile.",
     "languageDescription": "Use this application in this language. It will not be shown on your public profile.",
+    "changeLanguageError": "An error occurred when changing application language.",
     "accountPassword": "Account Password",
     "currentPassword": "Current Password",
     "currentPasswordDescription": "Enter your existing account password that you want to change.",

--- a/frontend/src/lib/i18n/translations/en/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/en/candidateApp.json
@@ -61,7 +61,7 @@
     },
     "emailDescription": "We use this email to connect to you and for password reset. It will not be shown on your public profile.",
     "languageDescription": "Use this application in this language. It will not be shown on your public profile.",
-    "changeLanguageError": "An error occurred when changing application language.",
+    "changeLanguageError": "An error occurred while changing the application language.",
     "accountPassword": "Account Password",
     "currentPassword": "Current Password",
     "currentPasswordDescription": "Enter your existing account password that you want to change.",

--- a/frontend/src/lib/i18n/translations/fi/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/fi/candidateApp.json
@@ -14,9 +14,9 @@
     "cancel": "Peruuta"
   },
   "languages": {
-    "English": "Englanniksi",
-    "Finnish": "Suomeksi",
-    "Spanish": "Espanjaksi"
+    "English": "Englanti",
+    "Finnish": "Suomi",
+    "Spanish": "Espanja"
   },
   "logoutModal": {
     "title": "Osa tiedoistasi puuttuu edelleen",

--- a/frontend/src/lib/i18n/translations/fi/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/fi/candidateApp.json
@@ -61,6 +61,7 @@
     },
     "emailDescription": "Käytämme tätä sähköpostia yhteydenottoon ja salasanan palauttamiseen. Se ei näy julkisessa profiilissasi.",
     "languageDescription": "Käytä tätä sovellusta tällä kielellä. Se ei näy julkisessa profiilissasi.",
+    "changeLanguageError": "Kielen vaihto epäonnistui.",
     "accountPassword": "Tilin salasana",
     "currentPassword": "Nykyinen salasana",
     "currentPasswordDescription": "Kirjoita tilisi nykyinen salasana, jonka haluat vaihtaa.",

--- a/frontend/src/lib/types/candidateAttributes.ts
+++ b/frontend/src/lib/types/candidateAttributes.ts
@@ -22,6 +22,7 @@ export interface Candidate {
   nominations: Nomination[];
   locale: string;
   party?: Party;
+  appLanguage?: Language;
 }
 
 export interface Language {

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/settings/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/settings/+page.svelte
@@ -30,7 +30,7 @@
   let validPassword = false;
   let errorMessage = '';
   let successMessage = '';
-  let langaugeErrorMessage = '';
+  let languageErrorMessage = '';
 
   $: disableSetButton = !validPassword || passwordConfirmation.length === 0;
 
@@ -46,7 +46,7 @@
 
   // Handle the change when the app language is changed
   const handleLanguageSelect = async (e: Event) => {
-    langaugeErrorMessage = '';
+    languageErrorMessage = '';
 
     const chosenLanguage = allLanguages
       ? allLanguages.find(
@@ -66,7 +66,7 @@
         await loadUserData(); // Reload user data so it's up to date
         await goto($getRoute({locale: languageObj.localisationCode})); // Change page language to the chosen one
       } catch (error) {
-        langaugeErrorMessage = $t('candidateApp.settings.changeLanguageError');
+        languageErrorMessage = $t('candidateApp.settings.changeLanguageError');
       }
     }
   };
@@ -151,9 +151,9 @@
     </p>
   </div>
 
-  {#if langaugeErrorMessage}
+  {#if languageErrorMessage}
     <p class="mb-0 mt-16 text-center text-error">
-      {langaugeErrorMessage}
+      {languageErrorMessage}
     </p>
   {/if}
 

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/settings/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/settings/+page.svelte
@@ -30,6 +30,7 @@
   let validPassword = false;
   let errorMessage = '';
   let successMessage = '';
+  let langaugeErrorMessage = '';
 
   $: disableSetButton = !validPassword || passwordConfirmation.length === 0;
 
@@ -45,6 +46,8 @@
 
   // Handle the change when the app language is changed
   const handleLanguageSelect = async (e: Event) => {
+    langaugeErrorMessage = '';
+
     const chosenLanguage = allLanguages
       ? allLanguages.find(
           (lang) => lang.attributes.localisationCode === (e.target as HTMLSelectElement).value
@@ -63,8 +66,7 @@
         await loadUserData(); // Reload user data so it's up to date
         await goto($getRoute({locale: languageObj.localisationCode})); // Change page language to the chosen one
       } catch (error) {
-        errorMessage = $t('candidateApp.settings.changeLanguageError');
-        //TODO change error message location?
+        langaugeErrorMessage = $t('candidateApp.settings.changeLanguageError');
       }
     }
   };
@@ -148,6 +150,12 @@
       {$t('candidateApp.settings.languageDescription')}
     </p>
   </div>
+
+  {#if langaugeErrorMessage}
+    <p class="mb-0 mt-16 text-center text-error">
+      {langaugeErrorMessage}
+    </p>
+  {/if}
 
   <!-- TODO: save settings button -->
   <!-- TODO: discard button -->


### PR DESCRIPTION
## WHY:

Finishes [#202](https://github.com/OpenVAA/voting-advice-application/issues/202)

### What has been changed (if possible, add screenshots, gifs, etc. )
User can now change their application language preference in the settings page. The preference is saved in the candidate object and the user is redirected to correct language route (if the preference has been set) when logging in.

![image](https://github.com/OpenVAA/voting-advice-application/assets/97187185/909ef1e0-99ae-4328-8210-f09ed60cea25)

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
