### PR TITLE
feat: locked textarea

### DIFF
--- a/frontend/src/lib/candidate/components/textArea/InputField.svelte
+++ b/frontend/src/lib/candidate/components/textArea/InputField.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type {TextAreaProps} from './TextArea.type';
+  import {Icon} from '$lib/components/icon';
 
   type $$Props = TextAreaProps;
 
@@ -9,6 +10,7 @@
   export let headerText: $$Props['headerText'] = undefined;
   export let disabled: $$Props['disabled'] = false;
   export let placeholder: $$Props['placeholder'] = '';
+  export let locked: $$Props['locked'] = false;
 </script>
 
 <!--
@@ -22,8 +24,9 @@ A compact text input field.
 - `id` (required): The id of the input field.
 - `text` (required): The text in the input field.
 - `headerText` (optional): The header text of the input field.
-- `disabled` (optional): If the input field is disabled.
+- `disabled` (optional): If the text area is disabled. This is used to indicate that the text area cannot be used yet.
 - `placeholder` (optional): The placeholder of the input field.
+- `locked` (optional): If the text area is locked and has a lock icon. This is used to indicate that the text can no longer be edited.
 
 ### Usage
 ```tsx
@@ -48,9 +51,14 @@ A compact text input field.
 <div class="flex w-full pr-6">
   <input
     type="text"
-    {disabled}
+    disabled={disabled && !locked}
+    readonly={locked}
     {id}
     {placeholder}
     bind:value={text}
     class="input input-sm input-ghost flex w-full justify-end pr-2 text-right disabled:border-none disabled:bg-base-100" />
 </div>
+
+{#if locked}
+  <Icon name="locked" class="my-auto flex-shrink-0 text-secondary" />
+{/if}

--- a/frontend/src/lib/candidate/components/textArea/MultilangTextInput.svelte
+++ b/frontend/src/lib/candidate/components/textArea/MultilangTextInput.svelte
@@ -16,6 +16,7 @@
   export let disabled: $$Props['disabled'] = false;
   export let compact: $$Props['compact'] = false;
   export let placeholder: $$Props['placeholder'] = '';
+  export let locked: $$Props['locked'] = false;
 
   export const deleteLocal = () => {
     if (!localStorageId) {
@@ -25,6 +26,11 @@
       localStorage.removeItem(localStorageId + '-' + locale);
     }
   };
+
+  // Locked indicates that the text can no longer be edited
+  // but still allows the user to view entered text including translations whereas
+  // disabled is used to indicate that the text area cannot be used yet
+  $: disabled = disabled && !locked; // Locked takes precedence over disabled
 
   let translationsShown = false;
   $: translationsShown = translationsShown && !disabled; // Hide translations if disabled
@@ -49,9 +55,10 @@ If all languages are shown, the header is shown for each language.
 - `localStorageId` (optional): The local storage id of the text area. If provided, the text is saved to local storage periodically.
 - `previouslySavedMultilang` (optional): The previously saved text in multiple languages. Is shown if there is no locally saved text.
 - `rows` (optional): The number of rows of the text area.
-- `disabled` (optional): If the text area is disabled.
+- `disabled` (optional): If the text area is disabled. This is used to indicate that the text area cannot be used yet.
 - `compact` (optional): If the text area is a multiline text area or a input field.
 - `placeholder` (optional): The placeholder of the text area. Shown for non-current locale text areas.
+- `locked` (optional): If the text area is locked and has a lock icon. This is used to indicate that the text can no longer be edited.
 
 ### Bindable functions
 - `deleteLocal`: Deletes the local storage for the text area. Used to clear the local storage from a parent component.
@@ -98,7 +105,8 @@ Input field variant
             bind:text={multilangText[$currentLocale]}
             id={id + '-' + $currentLocale}
             {headerText}
-            {disabled} />
+            {disabled}
+            {locked} />
         {:else}
           <TextArea
             bind:text={multilangText[$currentLocale]}
@@ -107,7 +115,8 @@ Input field variant
             localStorageId={localStorageId + '-' + $currentLocale}
             previouslySaved={previouslySavedMultilang?.[$currentLocale]}
             {rows}
-            {disabled} />
+            {disabled}
+            {locked} />
         {/if}
       </Field>
 
@@ -119,8 +128,9 @@ Input field variant
                 id={id + '-' + locale}
                 bind:text={multilangText[locale]}
                 headerText={$t(`lang.${locale}`)}
+                {placeholder}
                 {disabled}
-                {placeholder} />
+                {locked} />
             {:else}
               <TextArea
                 id={id + '-' + locale}
@@ -130,7 +140,8 @@ Input field variant
                 previouslySaved={previouslySavedMultilang?.[locale]}
                 {rows}
                 {disabled}
-                {placeholder} />
+                {placeholder}
+                {locked} />
             {/if}
           </Field>
         {/each}
@@ -139,7 +150,7 @@ Input field variant
   </FieldGroup>
 
   {#if translationsShown}
-    <p class="text-sm">{$t('candidateApp.textarea.info')}</p>
+    <p class="px-6 text-sm">{$t('candidateApp.textarea.info')}</p>
   {/if}
 
   <!-- Toggle whether translations are shown -->

--- a/frontend/src/lib/candidate/components/textArea/TextArea.svelte
+++ b/frontend/src/lib/candidate/components/textArea/TextArea.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {onMount, onDestroy} from 'svelte';
   import type {TextAreaProps} from './TextArea.type';
+  import {Icon} from '$lib/components/icon';
 
   type $$Props = TextAreaProps;
 
@@ -14,6 +15,9 @@
   export let disabled: $$Props['disabled'] = false;
   export let bgColor: $$Props['bgColor'] = 'bg-base-100';
   export let placeholder: $$Props['placeholder'] = '';
+  export let locked: $$Props['locked'] = false;
+
+  $: lockedClass = locked ? 'text-secondary' : '';
 
   const SAVE_INTERVAL_MS = 1000;
   let saveInterval: NodeJS.Timeout;
@@ -82,9 +86,10 @@ TextArea is a text area component with a header and a local storage save feature
 - `localStorageId` (optional): Local storage id for the saved text. If provided, content is saved to local storage periodically.
 - `previouslySaved` (optional): Previously saved text from the database, i.e. not locally saved. Is shown if there is no locally saved text.
 - `rows` (optional): The number of rows for the text area. Default is 4.
-- `disabled` (optional): Whether the text area is disabled. Default is false.
+- `disabled` (optional): If the text area is disabled. This is used to indicate that the text area cannot be used yet.
 - `bgColor` (optional): The background color of the text area. Default is 'bg-base-100'.
 - `placeholder` (optional): The placeholder text for the text area.
+- `locked` (optional): If the text area is locked and has a lock icon. This is used to indicate that the text can no longer be edited.
 
 ### Usage
 Usage without local saving:
@@ -110,7 +115,7 @@ Usage with local saving:
 ```
 -->
 
-<div class="w-full">
+<div class="relative w-full">
   {#if headerText}
     <label for={id} class="text-m mx-6 my-6 p-0 uppercase text-secondary">{headerText}</label>
   {:else}
@@ -120,9 +125,16 @@ Usage with local saving:
   <textarea
     {id}
     {rows}
-    {disabled}
     {placeholder}
-    class="textarea w-full resize-none p-6 !outline-none disabled:bg-base-300 {bgColor}"
+    disabled={disabled && !locked}
+    readonly={locked}
+    class="textarea w-full resize-none p-6 !outline-none disabled:bg-base-300 {bgColor} {lockedClass}"
     bind:value={text}
     on:focusout={saveToLocalStorage} />
+
+  {#if locked}
+    <div class="absolute bottom-0 right-0 m-10">
+      <Icon name="locked" class="my-auto flex-shrink-0 text-secondary" />
+    </div>
+  {/if}
 </div>

--- a/frontend/src/lib/candidate/components/textArea/TextArea.type.ts
+++ b/frontend/src/lib/candidate/components/textArea/TextArea.type.ts
@@ -30,6 +30,7 @@ export type TextAreaProps = {
   rows?: number;
   /**
    * Whether the textarea is disabled.
+   * This is used to indicate that the text area cannot be used yet.
    * @default false
    */
   disabled?: boolean;
@@ -43,6 +44,13 @@ export type TextAreaProps = {
    * @default ''
    */
   placeholder?: string;
+  /**
+   * Whether the textarea is locked. This is different from disabled and is set by the application admin.
+   * Locked textareas take precedence over disabled textareas and their appearance is different.
+   * Locked textareas are used to indicate that the user can no longer edit the text.
+   * @default false
+   */
+  locked?: boolean;
 };
 
 export type MultilangTextAreaProps = {


### PR DESCRIPTION
## WHY:

Advances #210 

### What has been changed (if possible, add screenshots, gifs, etc. )

Adds support for the TextArea component to be locked when candidates can no longer edit their answers.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
