### PR TITLE
Fix: Remove password set message repeat

### DIFF
--- a/frontend/src/lib/candidate/templates/login/LoginPage.svelte
+++ b/frontend/src/lib/candidate/templates/login/LoginPage.svelte
@@ -16,6 +16,7 @@
   let email = '';
   let password = '';
   let wrongCredentials = false;
+  let showPasswordSetMessage = false;
 
   // Variable for the user's chosen app language
   let appLanguageCode: string;
@@ -27,8 +28,6 @@
     if (!(await logIn(email, password))) {
       wrongCredentials = true;
     } else {
-      emailOfNewUserStore.set(null);
-
       // If user has chosen an app language, change to that language
       if (appLanguageCode) {
         await goto($getRoute({locale: appLanguageCode}));
@@ -37,6 +36,8 @@
   };
   if ($emailOfNewUserStore != null) {
     email = $emailOfNewUserStore;
+    showPasswordSetMessage = true;
+    emailOfNewUserStore.set(null);
   }
 </script>
 
@@ -59,7 +60,7 @@ Candidate login page. This component also takes care of the login process.
     <h1 class="text-3xl font-normal">{$page.data.election.name}</h1>
   </HeadingGroup>
   <form class="flex flex-col flex-nowrap items-center" on:submit|preventDefault={onLogin}>
-    {#if $emailOfNewUserStore !== null}
+    {#if showPasswordSetMessage}
       <p class="text-3xl font-normal">
         {$t('candidateApp.setPassword.passwordSetSuccesfully')}
       </p>


### PR DESCRIPTION

## WHY:

Succesfully registering gives the user a message about set password only the first time the login
page is loaded

### What has been changed (if possible, add screenshots, gifs, etc. )

## Check off each of the following tasks as they are completed

- [X] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [X] I have run the unit tests successfully.
- [X] I have run the e2e tests successfully.
- [X] I have tested this change on my own device.
- [X] I have tested this change on other devices (Using Browserstack is recommended).
- [X] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [X] I have added documentation where necessary.
- [X] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
