### PR TITLE
feat: enforce question editing on the backend

### DIFF
--- a/backend/vaa-strapi/src/api/answer/routes/answer.ts
+++ b/backend/vaa-strapi/src/api/answer/routes/answer.ts
@@ -5,6 +5,27 @@
 import { factories } from '@strapi/strapi';
 import { restrictResourceOwnedByCandidate, restrictPopulate, restrictFilters } from '../../../util/acl';
 
+const electionCanEditQuestions = async (ctx, config, {strapi}) => {
+  const {id} = ctx.params;
+
+  const answer = await strapi.db.query('api::answer.answer').findOne({
+    where: {id},
+    populate: {
+      question: {
+        populate: {
+          category: {
+            populate: {
+              election: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return answer?.question?.category?.election?.canEditQuestions ?? true; // If no election is set, then allowing editing questions by default
+};
+
 export default factories.createCoreRouter('api::answer.answer', {
   only: ['find', 'findOne', 'create', 'update', 'delete'],
   config: {
@@ -47,6 +68,8 @@ export default factories.createCoreRouter('api::answer.answer', {
           'candidate.id.$eq',
           'question.category.type.$eq',
         ]),
+        // Allow modification only when the current election allows it
+        electionCanEditQuestions,
       ],
     },
     update: {
@@ -64,6 +87,8 @@ export default factories.createCoreRouter('api::answer.answer', {
           'candidate.id.$eq',
           'question.category.type.$eq',
         ]),
+        // Allow modification only when the current election allows it
+        electionCanEditQuestions,
       ],
     },
     delete: {
@@ -79,6 +104,8 @@ export default factories.createCoreRouter('api::answer.answer', {
           'candidate.id.$eq',
           'question.category.type.$eq',
         ]),
+        // Allow modification only when the current election allows it
+        electionCanEditQuestions,
       ],
     },
   },


### PR DESCRIPTION
## WHY:

Enforces that the candidate can't create/update/delete questions if disabled for the election.

### What has been changed (if possible, add screenshots, gifs, etc. )

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?
