### PR TITLE
fix: make password set message look better

### DIFF
--- a/frontend/src/lib/candidate/templates/login/LoginPage.svelte
+++ b/frontend/src/lib/candidate/templates/login/LoginPage.svelte
@@ -61,7 +61,7 @@ Candidate login page. This component also takes care of the login process.
   </HeadingGroup>
   <form class="flex flex-col flex-nowrap items-center" on:submit|preventDefault={onLogin}>
     {#if showPasswordSetMessage}
-      <p class="text-3xl font-normal">
+      <p class="max-w-md text-3xl font-normal">
         {$t('candidateApp.setPassword.passwordSetSuccesfully')}
       </p>
     {/if}

--- a/frontend/src/lib/candidate/templates/login/LoginPage.svelte
+++ b/frontend/src/lib/candidate/templates/login/LoginPage.svelte
@@ -61,7 +61,7 @@ Candidate login page. This component also takes care of the login process.
   </HeadingGroup>
   <form class="flex flex-col flex-nowrap items-center" on:submit|preventDefault={onLogin}>
     {#if showPasswordSetMessage}
-      <p class="max-w-md text-center text-2xl font-normal">
+      <p class="max-w-md text-center text-2xl font-bold">
         {$t('candidateApp.setPassword.passwordSetSuccesfully')}
       </p>
     {/if}

--- a/frontend/src/lib/candidate/templates/login/LoginPage.svelte
+++ b/frontend/src/lib/candidate/templates/login/LoginPage.svelte
@@ -61,7 +61,7 @@ Candidate login page. This component also takes care of the login process.
   </HeadingGroup>
   <form class="flex flex-col flex-nowrap items-center" on:submit|preventDefault={onLogin}>
     {#if showPasswordSetMessage}
-      <p class="max-w-md text-3xl font-normal">
+      <p class="max-w-md text-center text-2xl font-normal">
         {$t('candidateApp.setPassword.passwordSetSuccesfully')}
       </p>
     {/if}

--- a/frontend/src/lib/i18n/translations/en/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/en/candidateApp.json
@@ -83,7 +83,7 @@
     "passwordsDontMatch": "Passwords don't match",
     "passwordNotValid": "Password is not valid",
     "registrationError": "Registration failed",
-    "passwordSetSuccesfully": "Your password is now set! Please login using it."
+    "passwordSetSuccesfully": "Your password is now set! Please log in using it."
   },
   "passwordValidation": {
     "length": "At least {minPasswordLength} characters",


### PR DESCRIPTION
## WHY:
Made "password set" message fit inside the standard width area 

### What has been changed (if possible, add screenshots, gifs, etc. )
![image](https://github.com/OpenVAA/voting-advice-application/assets/122307901/91d659f2-cb3e-4f0d-bc06-02aadb78e892)

## Check off each of the following tasks as they are completed

- [X] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [X] I have run the unit tests successfully.
- [X] I have run the e2e tests successfully.
- [X] I have tested this change on my own device.
- [X] I have tested this change on other devices (Using Browserstack is recommended).
- [X] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [X] I have added documentation where necessary.
- [X] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
