### PR TITLE
feat: candidate app progress bar

### DIFF
--- a/frontend/src/lib/candidate/components/candidateContext/CandidateContextProvider.svelte
+++ b/frontend/src/lib/candidate/components/candidateContext/CandidateContextProvider.svelte
@@ -51,18 +51,14 @@
   const updateProgress = () => {
     const answers = get(candidateContext.answersStore);
     const questions = get(candidateContext.questionsStore);
-    const basicInfoFilled = get(candidateContext.basicInfoFilledStore);
 
     if (answers && questions) {
       const answeredQuestions = Object.entries(answers).length;
       const totalQuestions = Object.entries(questions).length;
 
-      const basicInfoWeight = 3; // Weight of basic info in progress bar
-      const basicInfo = basicInfoFilled ? basicInfoWeight : 0;
-
       candidateContext.progressStore.set({
-        progress: 1 + answeredQuestions + basicInfo,
-        max: 1 + totalQuestions + basicInfoWeight
+        progress: answeredQuestions,
+        max: totalQuestions
       });
     }
   };
@@ -72,7 +68,6 @@
 
   candidateContext.answersStore.subscribe(updateProgress);
   candidateContext.questionsStore.subscribe(updateProgress);
-  candidateContext.basicInfoFilledStore.subscribe(updateProgress);
 </script>
 
 <!--

--- a/frontend/src/lib/candidate/components/candidateContext/CandidateContextProvider.svelte
+++ b/frontend/src/lib/candidate/components/candidateContext/CandidateContextProvider.svelte
@@ -33,7 +33,7 @@
       !!birthday,
       Object.values(manifesto).some((value) => value !== '')
     ].filter((n) => n).length;
-    candidateContext.nofUnasweredBasicInfoQuestionsStore.set(4 - nofBasicQuestionsFilled);
+    candidateContext.nofUnansweredBasicInfoQuestionsStore.set(4 - nofBasicQuestionsFilled);
   });
 
   const updateNofUnansweredQuestions = () => {
@@ -48,8 +48,31 @@
     }
   };
 
+  const updateProgress = () => {
+    const answers = get(candidateContext.answersStore);
+    const questions = get(candidateContext.questionsStore);
+    const basicInfoFilled = get(candidateContext.basicInfoFilledStore);
+
+    if (answers && questions) {
+      const answeredQuestions = Object.entries(answers).length;
+      const totalQuestions = Object.entries(questions).length;
+
+      const basicInfoWeight = 3; // Weight of basic info in progress bar
+      const basicInfo = basicInfoFilled ? basicInfoWeight : 0;
+
+      candidateContext.progressStore.set({
+        progress: 1 + answeredQuestions + basicInfo,
+        max: 1 + totalQuestions + basicInfoWeight
+      });
+    }
+  };
+
   candidateContext.answersStore.subscribe(updateNofUnansweredQuestions);
   candidateContext.questionsStore.subscribe(updateNofUnansweredQuestions);
+
+  candidateContext.answersStore.subscribe(updateProgress);
+  candidateContext.questionsStore.subscribe(updateProgress);
+  candidateContext.basicInfoFilledStore.subscribe(updateProgress);
 </script>
 
 <!--

--- a/frontend/src/lib/candidate/components/candidateContext/RequireAnswers.svelte
+++ b/frontend/src/lib/candidate/components/candidateContext/RequireAnswers.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type {CandidateContext} from '$lib/utils/candidateStore';
   import {getContext} from 'svelte';
+  import {LoadingSpinner} from '$candidate/components/loadingSpinner';
 
   const candidateContext = getContext<CandidateContext>('candidate');
   const answers = candidateContext.answersStore;
@@ -32,7 +33,7 @@ Require candidate answers to be loaded to view the children of this component.
   <slot />
 {:else}
   {#await getQuestionsAndAnswers()}
-    <span class="loading loading-spinner loading-lg" />
+    <LoadingSpinner />
   {:then}
     <slot />
   {/await}

--- a/frontend/src/lib/candidate/components/candidateContext/RequireLogin.svelte
+++ b/frontend/src/lib/candidate/components/candidateContext/RequireLogin.svelte
@@ -3,6 +3,7 @@
   import {getContext} from 'svelte';
   import {BasicPage} from '$lib/templates/basicPage';
   import {Warning} from '$lib/components/warning/index';
+  import {LoadingSpinner} from '$candidate/components/loadingSpinner';
   import {t} from '$lib/i18n';
   import type {CandidateContext} from '$lib/utils/candidateStore';
 
@@ -47,9 +48,7 @@ Require candidates to be logged in to view the children of this component.
     </BasicPage>
   {/if}
 {:else if ($tokenStore === undefined || ($tokenStore && !$userStore)) && showLogin}
-  <div class="mt-100 flex h-screen flex-col items-center">
-    <span class="loading loading-spinner loading-lg" />
-  </div>
+  <LoadingSpinner />
 {:else if showLogin}
   <LoginPage />
 {:else}

--- a/frontend/src/lib/candidate/components/loadingSpinner/LoadingSpinner.svelte
+++ b/frontend/src/lib/candidate/components/loadingSpinner/LoadingSpinner.svelte
@@ -1,0 +1,13 @@
+<!--
+@component
+A loading spinner component.
+
+### Usage
+```tsx
+<LoadingSpinner />
+```
+-->
+
+<div class="mt-100 flex h-screen flex-col items-center">
+  <span class="loading loading-spinner loading-lg" />
+</div>

--- a/frontend/src/lib/candidate/components/loadingSpinner/index.ts
+++ b/frontend/src/lib/candidate/components/loadingSpinner/index.ts
@@ -1,0 +1,1 @@
+export {default as LoadingSpinner} from './LoadingSpinner.svelte';

--- a/frontend/src/lib/candidate/components/logoutButton/LogoutButton.svelte
+++ b/frontend/src/lib/candidate/components/logoutButton/LogoutButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {t} from '$lib/i18n';
   import {getRoute, Route} from '$lib/utils/navigation';
-  import TimedModal from '$lib/components/modal/TimedModal.svelte';
+  import {TimedModal} from '$lib/components/modal';
   import {goto} from '$app/navigation';
   import {Button} from '$lib/components/button';
   import {getContext} from 'svelte';
@@ -21,26 +21,22 @@
     nofUnansweredBasicInfoQuestionsStore,
     opinionQuestionsFilledStore,
     nofUnansweredOpinionQuestionsStore,
+    basicInfoFilledStore,
     logOut
   } = getContext<CandidateContext>('candidate');
 
-  let opinionQuestionsLeft: number | undefined;
-  nofUnansweredBasicInfoQuestionsStore?.subscribe((value) => {
-    opinionQuestionsLeft = value;
-  });
-
-  let opinionQuestionsFilled: boolean | undefined;
-  opinionQuestionsFilledStore?.subscribe((value) => {
-    opinionQuestionsFilled = value;
-  });
-
   let basicInfoQuestionsLeft: number | undefined;
-  nofUnansweredOpinionQuestionsStore?.subscribe((value) => {
+  nofUnansweredBasicInfoQuestionsStore?.subscribe((value) => {
     basicInfoQuestionsLeft = value;
   });
 
+  let opinionQuestionsLeft: number | undefined;
+  nofUnansweredOpinionQuestionsStore?.subscribe((value) => {
+    opinionQuestionsLeft = value;
+  });
+
   const triggerLogout = () => {
-    if (!opinionQuestionsFilled || !basicInfoQuestionsLeft) {
+    if (!$opinionQuestionsFilledStore || !$basicInfoFilledStore) {
       openModal();
     } else {
       logout();
@@ -89,22 +85,16 @@ When set to false, the button variant is ghost.
   <div class="notification max-w-md text-center">
     <h2>{$t('candidateApp.logoutModal.title')}</h2>
     <br />
-    {#if basicInfoQuestionsLeft && basicInfoQuestionsLeft > 0}
+    {#if !$basicInfoFilledStore}
       <p>
-        {$t('candidateApp.logoutModal.body', {
-          remainingInfoAmount: basicInfoQuestionsLeft,
-          remainingOpinionNumber: opinionQuestionsLeft
-        })}
-      </p>
-    {:else if opinionQuestionsLeft && opinionQuestionsLeft > 1}
-      <p>
-        {$t('candidateApp.logoutModal.bodyBasicInfoReady', {
-          remainingOpinionNumber: opinionQuestionsLeft
+        {$t('candidateApp.logoutModal.itemsLeft', {
+          basicInfoQuestionsLeft,
+          opinionQuestionsLeft
         })}
       </p>
     {:else}
       <p>
-        {$t('candidateApp.logoutModal.bodyBasicInfoReady1OpinionLeft')}
+        {$t('candidateApp.logoutModal.questionsLeft', {opinionQuestionsLeft})}
       </p>
     {/if}
     <p>

--- a/frontend/src/lib/candidate/components/logoutButton/LogoutButton.svelte
+++ b/frontend/src/lib/candidate/components/logoutButton/LogoutButton.svelte
@@ -18,14 +18,14 @@
   let timeLeft = logoutModalTimer;
 
   const {
-    nofUnasweredBasicInfoQuestionsStore,
+    nofUnansweredBasicInfoQuestionsStore,
     opinionQuestionsFilledStore,
     nofUnansweredOpinionQuestionsStore,
     logOut
   } = getContext<CandidateContext>('candidate');
 
   let opinionQuestionsLeft: number | undefined;
-  nofUnasweredBasicInfoQuestionsStore?.subscribe((value) => {
+  nofUnansweredBasicInfoQuestionsStore?.subscribe((value) => {
     opinionQuestionsLeft = value;
   });
 

--- a/frontend/src/lib/candidate/components/passwordField/PasswordField.svelte
+++ b/frontend/src/lib/candidate/components/passwordField/PasswordField.svelte
@@ -29,7 +29,7 @@ to reveal and hide the password
 
 ### Usage
 ```tsx
-<PasswordField bind:password={passwordOfContext} autocomplete="autocomplete" />
+<PasswordField bind:password={passwordOfContext} autocomplete="current-password" />
 ```
 -->
 
@@ -56,5 +56,5 @@ to reveal and hide the password
       : $t('candidateApp.passwordButton.revealPassword')}
     class="absolute inset-y-0 right-0"
     icon={passwordRevealed ? 'hide' : 'show'}
-    on:click={() => changeRevealed()} />
+    on:click={changeRevealed} />
 </div>

--- a/frontend/src/lib/candidate/components/passwordSetter/PasswordSetter.svelte
+++ b/frontend/src/lib/candidate/components/passwordSetter/PasswordSetter.svelte
@@ -12,7 +12,7 @@
   export let validPassword = false;
 
   $: disableSetButton = validPassword && passwordConfirmation.length > 0;
-  //dispatcher used for a function that calls the submit button's function in parent component
+  // Dispatcher used for a function that calls the submit button's function in parent component
   export let buttonPressed = () => {};
 </script>
 
@@ -33,11 +33,11 @@ a second confirmation password input field, a button for submitting the password
 ```tsx
 
 <PasswordSetComponent
-bind:password={passwordOfContext1}
-bind:passwordConfirmation={passwordOfContext2}
-on:ButtonPressed={onSetButtonPressed}
-bind:validPassword={validPasswordOfContext}
-bind:errorMessage={errorMessageOfContext} />
+  bind:password={passwordOfContext1}
+  bind:passwordConfirmation={passwordOfContext2}
+  on:ButtonPressed={onSetButtonPressed}
+  bind:validPassword={validPasswordOfContext}
+  bind:errorMessage={errorMessageOfContext} />
 ```
 -->
 

--- a/frontend/src/lib/candidate/components/passwordValidator/PasswordValidator.svelte
+++ b/frontend/src/lib/candidate/components/passwordValidator/PasswordValidator.svelte
@@ -94,11 +94,11 @@ Therefore, the validity should be also checked on form submit as well and on the
 
 ### Usage
 
-  When using this component, the `validPassword` property should be bound to a boolean variable that is used to enable/disable the submit button.
-  `password` and `username` should be given as props.
-  ```tsx
-  <PasswordValidator bind:validPassword={validPassword} password={password} username={username} />
-  ```
+When using this component, the `validPassword` property should be bound to a boolean variable that is used to enable/disable the submit button.
+`password` and `username` should be given as props.
+```tsx
+<PasswordValidator bind:validPassword={validPassword} password={password} username={username} />
+```
 -->
 
 <div class="m-sm flex w-full flex-col">

--- a/frontend/src/lib/candidate/components/questionsPage/QuestionsStartPage.svelte
+++ b/frontend/src/lib/candidate/components/questionsPage/QuestionsStartPage.svelte
@@ -8,7 +8,7 @@
   import {getRoute, Route} from '$lib/utils/navigation';
   import type {CandidateContext} from '$lib/utils/candidateStore';
 
-  const {questionsStore} = getContext<CandidateContext>('candidate');
+  const {questionsStore, progressStore} = getContext<CandidateContext>('candidate');
   const questions = get(questionsStore) ?? [];
   const numQuestions = Object.values(questions).length;
   const firstQuestionUrl = $getRoute({
@@ -17,7 +17,10 @@
   });
 </script>
 
-<BasicPage title={$t('candidateApp.questions.start')}>
+<BasicPage
+  title={$t('candidateApp.questions.start')}
+  progress={$progressStore?.progress}
+  progressMax={$progressStore?.max}>
   <svelte:fragment slot="note">
     <Icon name="tip" />
     {$t('candidateApp.questions.tip')}

--- a/frontend/src/lib/candidate/components/questionsPage/QuestionsStartPage.svelte
+++ b/frontend/src/lib/candidate/components/questionsPage/QuestionsStartPage.svelte
@@ -8,7 +8,7 @@
   import {getRoute, Route} from '$lib/utils/navigation';
   import type {CandidateContext} from '$lib/utils/candidateStore';
 
-  const {questionsStore, progressStore} = getContext<CandidateContext>('candidate');
+  const {questionsStore} = getContext<CandidateContext>('candidate');
   const questions = get(questionsStore) ?? [];
   const numQuestions = Object.values(questions).length;
   const firstQuestionUrl = $getRoute({
@@ -17,10 +17,7 @@
   });
 </script>
 
-<BasicPage
-  title={$t('candidateApp.questions.start')}
-  progress={$progressStore?.progress}
-  progressMax={$progressStore?.max}>
+<BasicPage title={$t('candidateApp.questions.start')}>
   <svelte:fragment slot="note">
     <Icon name="tip" />
     {$t('candidateApp.questions.tip')}

--- a/frontend/src/lib/candidate/templates/question/QuestionPage.svelte
+++ b/frontend/src/lib/candidate/templates/question/QuestionPage.svelte
@@ -132,6 +132,11 @@
     goto($getRoute({route: Route.CandAppQuestions, id: nextUnansweredQuestion.id}));
   };
 
+  const cancelAndReturn = () => {
+    removeLocalAnswerToQuestion();
+    goto($getRoute(Route.CandAppQuestions));
+  };
+
   $: category = translate(currentQuestion.category, $locale);
   $: info = translate(currentQuestion.info, $locale);
   $: options = currentQuestion.values?.map(({key, label}) => ({
@@ -145,12 +150,12 @@
 Display the page for answering a single question.
 In addition to the question, includes a Likert scale and a text area for commenting.
 
-## Props
+### Properties
 - `currentQuestion` (required): The question to display.
 - `questions` (required): Record of all questions.
 - `editMode` (optional): Whether the page is in edit mode. Changes the buttons displayed.
 
-## Usage
+### Usage
 ```tsx
 <QuestionPage {currentQuestion} {questions} />
 ```
@@ -218,7 +223,7 @@ In addition to the question, includes a Likert scale and a text area for comment
             variant="main"
             text={$t('candidateApp.questions.saveAndReturn')} />
           <Button
-            on:click={() => goto($getRoute(Route.CandAppQuestions))}
+            on:click={cancelAndReturn}
             variant="main"
             text={$t('candidateApp.questions.cancel')} />
         </div>

--- a/frontend/src/lib/candidate/templates/question/QuestionPage.svelte
+++ b/frontend/src/lib/candidate/templates/question/QuestionPage.svelte
@@ -19,7 +19,7 @@
   export let questions: $$Props['questions'];
   export let editMode: $$Props['editMode'] = false;
 
-  const {answersStore} = getContext<CandidateContext>('candidate');
+  const {answersStore, progressStore} = getContext<CandidateContext>('candidate');
 
   $: answers = $answersStore;
   $: answer = answers?.[questionId]; // undefined if not answered
@@ -158,7 +158,11 @@ In addition to the question, includes a Likert scale and a text area for comment
 -->
 
 {#key currentQuestion}
-  <BasicPage title={translate(currentQuestion.text, $locale)} class="bg-base-200">
+  <BasicPage
+    title={translate(currentQuestion.text, $locale)}
+    class="bg-base-200"
+    progress={$progressStore?.progress}
+    progressMax={$progressStore?.max}>
     <Warning display={!currentQuestion.editable} slot="note"
       >{$t('questions.cannotEditWarning')}</Warning>
 

--- a/frontend/src/lib/i18n/translations/en/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/en/candidateApp.json
@@ -20,9 +20,8 @@
   },
   "logoutModal": {
     "title": "Some of Your Data Is Still Missing",
-    "body": "There are still {remainingInfoAmount} items of basic info and {remainingOpinionNumber} opinions to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
-    "bodyBasicInfoReady": "There are still {remainingOpinionNumber} opinions to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
-    "bodyBasicInfoReady1OpinionLeft": "There is still 1 opinion to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
+    "itemsLeft": "There {basicInfoQuestionsLeft, plural, =1 {is still one item} other {are still # items}} of basic info and {opinionQuestionsLeft, plural, =1 {one opinion} other {# opinions}} to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
+    "questionsLeft": "There {opinionQuestionsLeft, plural, =1 {is still one opinion} other {are still # opinions}} to fill. Your data won't be shown in the Election Compass until you have filled these, but you can login later to continue.",
     "confirmation": "Are you sure you want to logout? You will be automatically logged out after {timeLeft} seconds.",
     "continueEnteringData": "Continue Entering Data"
   },

--- a/frontend/src/lib/i18n/translations/fi/candidateApp.json
+++ b/frontend/src/lib/i18n/translations/fi/candidateApp.json
@@ -20,9 +20,8 @@
   },
   "logoutModal": {
     "title": "Osa tiedoistasi puuttuu edelleen",
-    "body": "Täytettävänä on vielä {remainingInfoAmount} perustietoa ja {remainingOpinionNumber} mielipidettä. Tietosi eivät näy vaalikoneessa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
-    "bodyBasicInfoReady": "Täytettävänä on vielä {remainingOpinionNumber} mielipidettä. Tietosi eivät näy vaalikoneessa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
-    "bodyBasicInfoReady1OpinionLeft": "Täytettävänä on vielä yksi mielipide. Tietosi eivät näy vaalikoneessa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
+    "itemsLeft": "Täytettävänä on vielä {basicInfoQuestionsLeft, plural, =1 {perustieto} other {# perustietoa}} ja {opinionQuestionsLeft, plural, =1 {yksi mielipide} other {# mielipidettä}}. Tietosi eivät näy vaalikoneessa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
+    "questionsLeft": "Täytettävä on vielä {opinionQuestionsLeft, plural, =1 {yksi mielipide} other {# mielipidettä}}. Tietosi eivät näy vaalikoneessa ennen kuin olet täyttänyt nämä kohdat, mutta voit kirjautua sisään myöhemmin jatkaaksesi.",
     "confirmation": "Oletko varma, että haluat kirjautua ulos? Sinut kirjataan automaattisesti ulos {timeLeft} sekunnin kuluttua.",
     "continueEnteringData": "Jatka tietojen syöttämistä"
   },

--- a/frontend/src/lib/templates/page/Page.svelte
+++ b/frontend/src/lib/templates/page/Page.svelte
@@ -194,4 +194,7 @@ the Drawer component.
   #main-progress-bar::-webkit-meter-optimum-value {
     @apply rounded-r-full bg-primary bg-none;
   }
+  #main-progress-bar::-moz-meter-bar {
+    @apply rounded-r-full bg-primary bg-none;
+  }
 </style>

--- a/frontend/src/lib/types/candidateAttributes.ts
+++ b/frontend/src/lib/types/candidateAttributes.ts
@@ -116,3 +116,8 @@ interface QuestionChoiceProps {
   key: number;
   label: LocalizedString;
 }
+
+export interface Progress {
+  progress: number;
+  max: number;
+}

--- a/frontend/src/lib/utils/candidateStore.ts
+++ b/frontend/src/lib/utils/candidateStore.ts
@@ -1,5 +1,5 @@
 import {authenticate, me} from '$lib/api/candidate';
-import type {Question, Answer, User} from '$lib/types/candidateAttributes';
+import type {Question, Answer, User, Progress} from '$lib/types/candidateAttributes';
 import {writable, type Writable} from 'svelte/store';
 import {getExistingAnswers} from '$lib/api/candidate';
 import {getLikertQuestions} from '$lib/api/candidate';
@@ -21,9 +21,10 @@ export interface CandidateContext {
   loadQuestionData: () => Promise<void>;
   // Custom util
   basicInfoFilledStore: Writable<boolean | undefined>;
-  nofUnasweredBasicInfoQuestionsStore: Writable<number | undefined>;
+  nofUnansweredBasicInfoQuestionsStore: Writable<number | undefined>;
   opinionQuestionsFilledStore: Writable<boolean | undefined>;
   nofUnansweredOpinionQuestionsStore: Writable<number | undefined>;
+  progressStore: Writable<Progress | undefined>;
 }
 
 const userStore = writable<User | null>(null);
@@ -35,6 +36,7 @@ const basicInfoFilledStore = writable<boolean | undefined>(undefined);
 const nofUnansweredBasicInfoQuestionsStore = writable<number | undefined>(undefined);
 const opinionQuestionsFilledStore = writable<boolean | undefined>(undefined);
 const nofUnansweredOpinionQuestionsStore = writable<number | undefined>(undefined);
+const progressStore = writable<Progress | undefined>(undefined);
 
 const logIn = async (email: string, password: string) => {
   const response = await authenticate(email, password);
@@ -98,7 +100,8 @@ export const candidateContext: CandidateContext = {
   loadQuestionData,
   loadLocalStorage,
   basicInfoFilledStore,
-  nofUnansweredOpinionQuestionsStore: nofUnansweredOpinionQuestionsStore,
+  nofUnansweredOpinionQuestionsStore,
   opinionQuestionsFilledStore,
-  nofUnasweredBasicInfoQuestionsStore: nofUnansweredBasicInfoQuestionsStore
+  nofUnansweredBasicInfoQuestionsStore,
+  progressStore
 };

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/+page.svelte
@@ -13,10 +13,11 @@
   const {
     userStore,
     basicInfoFilledStore,
-    nofUnasweredBasicInfoQuestionsStore: nofUnansweredBasicInfoQuestions,
+    nofUnansweredBasicInfoQuestionsStore: nofUnansweredBasicInfoQuestions,
     opinionQuestionsFilledStore,
     nofUnansweredOpinionQuestionsStore: nofUnansweredOpinionQuestions,
-    questionsStore
+    questionsStore,
+    progressStore
   } = getContext<CandidateContext>('candidate');
   const user = get(userStore);
   const userName = user?.candidate?.firstName;
@@ -86,7 +87,10 @@
 
 <!--Homepage for the user-->
 
-<BasicPage title={nextAction.title}>
+<BasicPage
+  title={nextAction.title}
+  progress={$progressStore?.progress}
+  progressMax={$progressStore?.max}>
   <Warning display={!dataEditable} slot="note">
     <p>{$t('candidateApp.homePage.editingNotAllowedNote')}</p>
     {#if !opinionQuestionsFilled || !basicInfoFilled}

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {t} from '$lib/i18n';
+  import {t, locale} from '$lib/i18n';
   import {BasicPage} from '$lib/templates/basicPage';
   import {Button} from '$lib/components/button';
   import {getRoute, Route} from '$lib/utils/navigation';
@@ -16,8 +16,7 @@
     nofUnansweredBasicInfoQuestionsStore: nofUnansweredBasicInfoQuestions,
     opinionQuestionsFilledStore,
     nofUnansweredOpinionQuestionsStore: nofUnansweredOpinionQuestions,
-    questionsStore,
-    progressStore
+    questionsStore
   } = getContext<CandidateContext>('candidate');
   const user = get(userStore);
   const userName = user?.candidate?.firstName;
@@ -82,15 +81,15 @@
     };
   };
 
-  $: nextAction = getNextAction();
+  $: nextAction = {
+    $locale, // Trigger reactivity when locale changes
+    ...getNextAction()
+  };
 </script>
 
 <!--Homepage for the user-->
 
-<BasicPage
-  title={nextAction.title}
-  progress={$progressStore?.progress}
-  progressMax={$progressStore?.max}>
+<BasicPage title={nextAction.title}>
   <Warning display={!dataEditable} slot="note">
     <p>{$t('candidateApp.homePage.editingNotAllowedNote')}</p>
     {#if !opinionQuestionsFilled || !basicInfoFilled}

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+  import type {CandidateContext} from '$lib/utils/candidateStore';
   import {getContext} from 'svelte';
   import {LogoutButton} from '$lib/candidate/components/logoutButton';
-  import type {CandidateContext} from '$lib/utils/candidateStore';
   import {CandidateDetailsCard} from '$lib/components/candidates';
   import {SingleCardPage} from '$lib/templates/singleCardPage';
   import {locale, t} from '$lib/i18n';
   import {Icon} from '$lib/components/icon';
+  import {LoadingSpinner} from '$candidate/components/loadingSpinner';
   import {getInfoQuestions, getOpinionQuestions, getNominatedCandidates} from '$lib/api/getData';
 
   const {userStore} = getContext<CandidateContext>('candidate');
@@ -17,22 +18,29 @@
   getOpinionQuestions({locale: $locale}).then((res) => (opinionQuestions = res));
 
   let candidate: CandidateProps | undefined;
-  getNominatedCandidates({
-    loadAnswers: true,
-    locale: $locale,
-    id: $userStore?.candidate?.id.toString()
-  }).then((res) => (candidate = res[0]));
+  const loadCandidate = async () => {
+    const res = await getNominatedCandidates({
+      loadAnswers: true,
+      locale: $locale,
+      id: $userStore?.candidate?.id.toString()
+    });
+    candidate = res[0];
+  };
 </script>
 
-{#if !candidate}
-  <span>{$t('candidateApp.preview.notFound')}</span>
-{:else}
-  <SingleCardPage title={$t('candidateApp.preview.title')}>
-    <svelte:fragment slot="note">
-      <Icon name="info" />
-      {$t('candidateApp.preview.tip')}
-    </svelte:fragment>
-    <LogoutButton slot="banner" />
-    <CandidateDetailsCard {candidate} {opinionQuestions} {infoQuestions} />
-  </SingleCardPage>
-{/if}
+{#await loadCandidate()}
+  <LoadingSpinner />
+{:then}
+  {#if !candidate}
+    <span>{$t('candidateApp.preview.notFound')}</span>
+  {:else}
+    <SingleCardPage title={$t('candidateApp.preview.title')}>
+      <svelte:fragment slot="note">
+        <Icon name="info" />
+        {$t('candidateApp.preview.tip')}
+      </svelte:fragment>
+      <LogoutButton slot="banner" />
+      <CandidateDetailsCard {candidate} {opinionQuestions} {infoQuestions} />
+    </SingleCardPage>
+  {/if}
+{/await}

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/profile/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/profile/+page.svelte
@@ -31,7 +31,7 @@
   const inputContainerClass = 'flex w-full pr-6';
 
   // get the user from authContext
-  const {userStore, loadUserData, progressStore} = getContext<CandidateContext>('candidate');
+  const {userStore, loadUserData} = getContext<CandidateContext>('candidate');
   const user = get(userStore);
 
   let loading = false;
@@ -79,10 +79,6 @@
     motherTongues.length > 0 &&
     !!birthday &&
     Object.values(manifesto).some((value) => value !== '');
-
-  // Advance progress bar when user navigates to the profile page
-  // Part of the total progress for basic info and used when profile is not yet filled
-  $: openedProfileIncrease = allFilled ? 0 : 1;
 
   let errorMessage: string | undefined;
 
@@ -177,11 +173,7 @@
   };
 </script>
 
-<BasicPage
-  title={$t('candidateApp.basicInfo.title')}
-  mainClass="bg-base-200"
-  progress={($progressStore?.progress ?? 0) + openedProfileIncrease}
-  progressMax={$progressStore?.max}>
+<BasicPage title={$t('candidateApp.basicInfo.title')} mainClass="bg-base-200">
   <PreventNavigation active={dirty && !loading} />
   <form on:submit|preventDefault={submitForm}>
     <div class="flex flex-col items-center gap-16">

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/profile/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/profile/+page.svelte
@@ -31,7 +31,7 @@
   const inputContainerClass = 'flex w-full pr-6';
 
   // get the user from authContext
-  const {userStore, loadUserData} = getContext<CandidateContext>('candidate');
+  const {userStore, loadUserData, progressStore} = getContext<CandidateContext>('candidate');
   const user = get(userStore);
 
   let loading = false;
@@ -79,6 +79,10 @@
     motherTongues.length > 0 &&
     !!birthday &&
     Object.values(manifesto).some((value) => value !== '');
+
+  // Advance progress bar when user navigates to the profile page
+  // Part of the total progress for basic info and used when profile is not yet filled
+  $: openedProfileIncrease = allFilled ? 0 : 1;
 
   let errorMessage: string | undefined;
 
@@ -173,8 +177,12 @@
   };
 </script>
 
-<BasicPage title={$t('candidateApp.basicInfo.title')} mainClass="bg-base-200">
-  <PreventNavigation active={dirty} />
+<BasicPage
+  title={$t('candidateApp.basicInfo.title')}
+  mainClass="bg-base-200"
+  progress={($progressStore?.progress ?? 0) + openedProfileIncrease}
+  progressMax={$progressStore?.max}>
+  <PreventNavigation active={dirty && !loading} />
   <form on:submit|preventDefault={submitForm}>
     <div class="flex flex-col items-center gap-16">
       <p class="text-center">

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/+layout.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/+layout.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-  import {goto} from '$app/navigation';
-  import {t} from '$lib/i18n';
   import type {CandidateContext} from '$lib/utils/candidateStore';
   import {getContext} from 'svelte';
+  import {goto} from '$app/navigation';
+  import {t} from '$lib/i18n';
   import {get} from 'svelte/store';
   import {getRoute, Route} from '$lib/utils/navigation';
+  import {LoadingSpinner} from '$candidate/components/loadingSpinner';
 
   const {basicInfoFilledStore, questionsStore} = getContext<CandidateContext>('candidate');
-  if (!get(basicInfoFilledStore)) {
+
+  $: if (!get(basicInfoFilledStore)) {
     goto($getRoute(Route.CandAppProfile));
   }
 
@@ -18,7 +20,9 @@
   <title>{$t('questions.questionsTitle')}</title>
 </svelte:head>
 
-{#if !questions || !Object.values(questions).length}
+{#if !get(basicInfoFilledStore)}
+  <LoadingSpinner />
+{:else if !questions || !Object.values(questions).length}
   <p>{$t('error.noQuestions')}</p>
 {:else}
   <slot />

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/+layout.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/+layout.svelte
@@ -3,13 +3,12 @@
   import {getContext} from 'svelte';
   import {goto} from '$app/navigation';
   import {t} from '$lib/i18n';
-  import {get} from 'svelte/store';
   import {getRoute, Route} from '$lib/utils/navigation';
   import {LoadingSpinner} from '$candidate/components/loadingSpinner';
 
   const {basicInfoFilledStore, questionsStore} = getContext<CandidateContext>('candidate');
 
-  $: if (!get(basicInfoFilledStore)) {
+  $: if (!$basicInfoFilledStore) {
     goto($getRoute(Route.CandAppProfile));
   }
 
@@ -20,7 +19,7 @@
   <title>{$t('questions.questionsTitle')}</title>
 </svelte:head>
 
-{#if !get(basicInfoFilledStore)}
+{#if !$basicInfoFilledStore}
   <LoadingSpinner />
 {:else if !questions || !Object.values(questions).length}
   <p>{$t('error.noQuestions')}</p>

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/questions/+page.svelte
@@ -21,7 +21,8 @@
     opinionQuestionsFilledStore,
     nofUnansweredOpinionQuestionsStore,
     questionsStore,
-    answersStore
+    answersStore,
+    progressStore
   } = getContext<CandidateContext>('candidate');
 
   let dataEditable: boolean;
@@ -94,7 +95,10 @@
 {#if answers && Object.entries(answers).length === 0}
   <QuestionsStartPage />
 {:else}
-  <BasicPage title={$t('candidateApp.questions.title')}>
+  <BasicPage
+    title={$t('candidateApp.questions.title')}
+    progress={$progressStore?.progress}
+    progressMax={$progressStore?.max}>
     <Warning display={!dataEditable} slot="note">
       <p>{$t('candidateApp.questions.editingAllowedNote')}</p>
       {#if !opinionQuestionsFilled || !basicInfoFilled}

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/settings/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/settings/+page.svelte
@@ -14,7 +14,7 @@
   import type {StrapiLanguageData} from '$lib/api/getData.type';
   import type {Language} from '$lib/types/candidateAttributes';
 
-  const {userStore, loadUserData} = getContext<CandidateContext>('candidate');
+  const {userStore, loadUserData, progressStore} = getContext<CandidateContext>('candidate');
   $: user = $userStore;
 
   // TODO: consider refactoring this as this uses same classes as profile/+page.svelte?
@@ -102,7 +102,11 @@
   };
 </script>
 
-<BasicPage title={$t('candidateApp.settings.title')} mainClass="bg-base-200">
+<BasicPage
+  title={$t('candidateApp.settings.title')}
+  mainClass="bg-base-200"
+  progress={$progressStore?.progress}
+  progressMax={$progressStore?.max}>
   <div class="text-center">
     <p>{$t('candidateApp.settings.instructions')}</p>
   </div>

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/settings/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/settings/+page.svelte
@@ -14,7 +14,7 @@
   import type {StrapiLanguageData} from '$lib/api/getData.type';
   import type {Language} from '$lib/types/candidateAttributes';
 
-  const {userStore, loadUserData, progressStore} = getContext<CandidateContext>('candidate');
+  const {userStore, loadUserData} = getContext<CandidateContext>('candidate');
   $: user = $userStore;
 
   // TODO: consider refactoring this as this uses same classes as profile/+page.svelte?
@@ -97,16 +97,17 @@
       return;
     }
 
+    // Clear fields on success
+    currentPassword = '';
+    password = '';
+    passwordConfirmation = '';
+
     errorMessage = '';
     successMessage = $t('candidateApp.settings.passwordUpdated');
   };
 </script>
 
-<BasicPage
-  title={$t('candidateApp.settings.title')}
-  mainClass="bg-base-200"
-  progress={$progressStore?.progress}
-  progressMax={$progressStore?.max}>
+<BasicPage title={$t('candidateApp.settings.title')} mainClass="bg-base-200">
   <div class="text-center">
     <p>{$t('candidateApp.settings.instructions')}</p>
   </div>

--- a/frontend/src/routes/[[lang=locale]]/candidate/register/RegistrationCodePage.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/register/RegistrationCodePage.svelte
@@ -49,7 +49,7 @@ registrationCode
   </HeadingGroup>
   <div slot="header">
     {#if loggedIn}
-      <LogoutButton></LogoutButton>
+      <LogoutButton />
     {/if}
   </div>
   <form class="flex flex-col flex-nowrap items-center" on:submit|preventDefault={onRegistration}>


### PR DESCRIPTION
## WHY:

Implements the progress bar in candidate app.

### What has been changed (if possible, add screenshots, gifs, etc. )

The candidate app now uses the progress bar of the Page component.
Additionally, improves UX by adding loading indicators to profile preview and checking the basic page fill status on
/questions route. A basic loading spinner component is added to standardize the style of loading indicators.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
