### PR TITLE
fix: restrict birthday range

### DIFF
--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/profile/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/profile/+page.svelte
@@ -171,6 +171,9 @@
       motherTongueSelect.selectedIndex = 0;
     }
   };
+
+  const birthdayMin = '1800-01-01';
+  const birthdayMax = new Date().toISOString().split('T')[0];
 </script>
 
 <BasicPage title={$t('candidateApp.basicInfo.title')} mainClass="bg-base-200">
@@ -234,7 +237,13 @@
           </label>
           <div class={inputContainerClass}>
             <div class={inputClass}>
-              <input class="dark:bg-black" type="date" id="birthday" bind:value={birthday} />
+              <input
+                class="dark:bg-black"
+                type="date"
+                min={birthdayMin}
+                max={birthdayMax}
+                id="birthday"
+                bind:value={birthday} />
             </div>
           </div>
         </Field>


### PR DESCRIPTION
## WHY:

Fixes being able to enter an unrealistic birthday.

### What has been changed (if possible, add screenshots, gifs, etc. )

The date input now enforces birthday to be between year 1800 and current date.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?