### PR TITLE
fix: candidate preview texts

### DIFF
--- a/frontend/src/lib/components/candidates/CandidateDetailsCard.svelte
+++ b/frontend/src/lib/components/candidates/CandidateDetailsCard.svelte
@@ -15,6 +15,8 @@
   export let opinionQuestions: QuestionProps[];
   /** An optional Ranking object used for showing the Candidate's match with the Voter */
   export let ranking: RankingProps | undefined = undefined;
+  /** An optional props to define wether component is used on the candidate or voter's side*/
+  export let candidateView: CandidateDetailsCardProps['candidateView'] = false;
 
   // Tabs
   let tabs: string[];
@@ -88,6 +90,6 @@ TODO: This component is still a work in progress and does not follow the propert
   {#if tabs[0] === activeItem}
     <CandidateBasicInfo {candidate} questions={infoQuestions} />
   {:else if tabs[1] === activeItem}
-    <CandidateOpinions {candidate} questions={opinionQuestions} />
+    <CandidateOpinions {candidate} questions={opinionQuestions} {candidateView} />
   {/if}
 </article>

--- a/frontend/src/lib/components/candidates/CandidateOpinions.svelte
+++ b/frontend/src/lib/components/candidates/CandidateOpinions.svelte
@@ -5,6 +5,9 @@
   import {HeadingGroup, PreHeading} from '$lib/components/headingGroup';
   import {getLikertAnswer} from '$lib/utils/answers';
 
+  /** An optinal props to define wether component is used on the candidate or voter's side*/
+  export let candidateView: CandidateDetailsCardProps['candidateView'] = false;
+
   export let candidate: CandidateProps;
   export let questions: QuestionProps[];
 
@@ -24,11 +27,15 @@
         <h3>{text}</h3>
       </HeadingGroup>
 
-      {#if voterAnswer == null && answer == null}
+      {#if voterAnswer == null && answer == null && !candidateView}
         <div class="small-label mb-16 text-center">
           {$t('questions.bothHaventAnswered').replace('{{candidate}}', shortName)}
         </div>
-      {:else if voterAnswer == null}
+      {:else if voterAnswer == null && answer == null && candidateView}
+        <div class="small-label mb-16 text-center">
+          {$t('questions.youHaventAnswered')}
+        </div>
+      {:else if voterAnswer == null && !candidateView}
         <div class="small-label mb-16 text-center">
           {$t('questions.youHaventAnswered')}
         </div>

--- a/frontend/src/lib/types/global.d.ts
+++ b/frontend/src/lib/types/global.d.ts
@@ -230,4 +230,13 @@ declare global {
       };
     }[];
   }
+
+  export type CandidateDetailsCardProps = {
+    /**
+     *  Defines whether component is used to show candidate's preview or if it is
+     * used in the voter side to render both candidate's and voters answers.
+     * */
+
+    candidateView?: boolean;
+  };
 }

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
@@ -40,7 +40,7 @@
         {$t('candidateApp.preview.tip')}
       </svelte:fragment>
       <LogoutButton buttonVariant="icon" slot="banner" />
-      <CandidateDetailsCard {candidate} {opinionQuestions} {infoQuestions} />
+      <CandidateDetailsCard {candidate} {opinionQuestions} {infoQuestions} candidateView={true} />
     </SingleCardPage>
   {/if}
 {/await}

--- a/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/candidate/(protected)/preview/+page.svelte
@@ -40,7 +40,7 @@
         {$t('candidateApp.preview.tip')}
       </svelte:fragment>
       <LogoutButton buttonVariant="icon" slot="banner" />
-      <CandidateDetailsCard {candidate} {opinionQuestions} {infoQuestions} candidateView={true} />
+      <CandidateDetailsCard {candidate} {opinionQuestions} {infoQuestions} candidateView />
     </SingleCardPage>
   {/if}
 {/await}


### PR DESCRIPTION
## WHY:

The candidate preview texts have been fixed to show correct information.

### What has been changed (if possible, add screenshots, gifs, etc. )

Modified CandidateDetailsCard and CandidateOpinions component to show different texts based on the application side they are used.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
