### PR TITLE
fix: add documentation to candidate app

### DIFF
--- a/frontend/src/lib/candidate/components/questionsPage/AnsweredQuestion.svelte
+++ b/frontend/src/lib/candidate/components/questionsPage/AnsweredQuestion.svelte
@@ -43,6 +43,20 @@
   };
 </script>
 
+<!--
+@component
+Renders an answered question on the summary page. Consists of the questions title, likert responses,
+open answers and a button to navigate to the questions page.
+
+-`question`: The question that is rendered. Taken as a mandatory prop
+-`categoryQuestions`: All the questions belonging to the same category. Taken as a mandatory prop
+
+### Usage
+```tsx
+  <AnsweredQuestion {question} {categoryQuestions} />
+```
+-->
+
 {#if answers?.[question.id]}
   <div class="pb-20 pt-20">
     <div class="text-accent">

--- a/frontend/src/lib/candidate/components/questionsPage/QuestionsStartPage.svelte
+++ b/frontend/src/lib/candidate/components/questionsPage/QuestionsStartPage.svelte
@@ -10,12 +10,26 @@
 
   const {questionsStore} = getContext<CandidateContext>('candidate');
   const questions = get(questionsStore) ?? [];
+
   const numQuestions = Object.values(questions).length;
   const firstQuestionUrl = $getRoute({
     route: Route.CandAppQuestions,
     id: Object.values(questions)[0].id
   });
 </script>
+
+<!--
+@component
+Renders the question start page, which tells the user information on how to answer the questions.
+
+-`numQuestions`: The number of questions to be answered.
+-`firstQuestionUrl`: The url of the first question where the user is navigated to after the start page.
+
+### Usage
+```tsx
+  <QuestionsStartPage />
+```
+-->
 
 <BasicPage title={$t('candidateApp.questions.start')}>
   <svelte:fragment slot="note">

--- a/frontend/src/lib/candidate/components/questionsPage/QuestionsStartPage.svelte
+++ b/frontend/src/lib/candidate/components/questionsPage/QuestionsStartPage.svelte
@@ -11,7 +11,9 @@
   const {questionsStore} = getContext<CandidateContext>('candidate');
   const questions = get(questionsStore) ?? [];
 
+  // The number of questions to be answered.
   const numQuestions = Object.values(questions).length;
+  // The url of the first question where the user is navigated to after the start page.
   const firstQuestionUrl = $getRoute({
     route: Route.CandAppQuestions,
     id: Object.values(questions)[0].id
@@ -21,9 +23,6 @@
 <!--
 @component
 Renders the question start page, which tells the user information on how to answer the questions.
-
--`numQuestions`: The number of questions to be answered.
--`firstQuestionUrl`: The url of the first question where the user is navigated to after the start page.
 
 ### Usage
 ```tsx

--- a/frontend/src/lib/candidate/components/questionsPage/UnAnsweredQuestion.svelte
+++ b/frontend/src/lib/candidate/components/questionsPage/UnAnsweredQuestion.svelte
@@ -26,6 +26,19 @@
   }
 </script>
 
+<!--
+@component
+Renders an unanswered question on the summary page. Consists of the questions title and a button to navigate to the questions page.
+
+-`question`: The question that is rendered. Taken as a mandatory prop
+-`categoryQuestions`: All the questions belonging to the same category. Taken as a mandatory prop
+
+### Usage
+```tsx
+  <UnAnsweredQuestion {question} {categoryQuestions} />
+```
+-->
+
 <div class="pt-40">
   <div class="text-accent">
     {translate(question.category)}


### PR DESCRIPTION
## WHY:

Adds documentation to AnsweredQuestion.svelte, QuestionsStartPage.svelte and UnAnsweredQuestions.svelte

### What has been changed (if possible, add screenshots, gifs, etc. )

Adds documentation to AnsweredQuestion.svelte, QuestionsStartPage.svelte and UnAnsweredQuestions.svelte

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [ ] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
