### PR TITLE
fix: candidate manifesto creation

### DIFF
--- a/backend/vaa-strapi/src/api/candidate/content-types/candidate/lifecycles.ts
+++ b/backend/vaa-strapi/src/api/candidate/content-types/candidate/lifecycles.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 export default {
   beforeCreate(event) {
     event.params.data.registrationKey = event.params.data.registrationKey ?? crypto.randomUUID();
+    event.params.data.manifesto = event.params.data.manifesto ?? {};
     event.params.data.email = event.params.data.email?.toLowerCase();
   },
   beforeUpdate(event) {


### PR DESCRIPTION
## WHY:

Manifesto was null instead of {} when candidate was imported or created in Strapi.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
