### PR TITLE
feat: add tests for settings and nav

### DIFF
--- a/tests/navbar.spec.ts
+++ b/tests/navbar.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+test.describe.serial('nav bar buttons should work expectedly', () => {
+  test('should change app language through nav', async ({ page }) => {
+
+    await page.goto('http://localhost:5173/en/candidate');
+
+    //Check that nav buttons change page to correct locale
+    await page.getByLabel('Open menu').click();
+    await page.getByRole('link', { name: 'Suomi' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/fi\/candidate/);
+
+    await page.getByRole('link', { name: 'English' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/en\/candidate/);
+
+    await page.getByRole('link', { name: 'Español (Colombia)' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/es-CO\/candidate/);
+
+  });
+
+  test('nav buttons should take to correct pages', async ({ page }) => {
+
+    await page.goto('http://localhost:5173/en/candidate');
+
+    //Check that nav links go to correct pages
+    await page.getByLabel('Open menu').click();
+    await page.getByRole('link', { name: 'Basic Info' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/en\/candidate\/profile/);
+
+    await page.getByLabel('Open menu').click();
+    await page.getByRole('link', { name: 'Your Opinions' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/en\/candidate\/questions/);
+
+    await page.getByLabel('Open menu').click();
+    await page.getByRole('link', { name: 'Settings' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/en\/candidate\/settings/);
+
+    await page.getByLabel('Open menu').click();
+    await page.getByRole('link', { name: 'Preview' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/en\/candidate\/preview/);
+
+    await page.getByLabel('Open menu').click();
+    await page.getByRole('link', { name: 'Help' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/en\/candidate\/help/);
+
+    await page.getByLabel('Open menu').click();
+    await page.getByRole('link', { name: 'Start' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/en\/candidate/);
+
+  });
+});

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test.describe.serial('settings page should work expectedly', () => {
+  test('should change app language', async ({ page }) => {
+    
+    //Go to setting and change language to en
+    await page.goto('http://localhost:5173/fi/candidate/settings');
+    await page.getByLabel('Sovelluksen kieli').selectOption('en');
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/en\/candidate\/settings/);
+
+    //Log out
+    await page.getByLabel('Logout').click();
+
+    //Change page language to fi
+    await page.getByLabel('Open menu').click();
+    await page.getByRole('link', { name: 'Suomi' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/fi\/candidate/);
+    await page.locator('.drawer-overlay').click();
+
+    //Sign in and expect language to automatically change to en
+    await page.getByPlaceholder('example@email.com').fill('first.last@example.com');
+    await page.getByPlaceholder('Esim. CP23-174a-f4%&-aHAB').fill('password');
+    await page.getByRole('button', { name: 'FI - Sign in' }).click();
+    await expect(page).toHaveURL(/(http[s]?:\/\/)?(.*)\/en\/candidate/);
+
+  });
+
+  test('should update password', async ({ page }) => {
+    
+    //Go to settings and change password 
+    await page.goto('http://localhost:5173/en/candidate/settings');    
+    await page.getByLabel('Current Password').fill('password');
+    await page.getByLabel('New Password', { exact: true }).fill('Password1!');
+    await page.getByLabel('New Password Confirmation').fill('Password1!');
+    await page.getByRole('button', { name: 'Update Password' }).click();
+    await expect(page.getByText('The password has been updated!')).toBeVisible();
+
+    //Logout
+    await page.getByLabel('Logout').click();
+
+    //Should not login with old password
+    await page.getByPlaceholder('example@email.com').fill('first.last@example.com');
+    await page.getByPlaceholder('E.g. CP23-174a-f4%&-aHAB').fill('password');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page.getByText('Wrong email or password')).toBeVisible();
+
+    //Should login with new password
+    await page.getByPlaceholder('E.g. CP23-174a-f4%&-aHAB').fill('Password1!');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page.getByRole('heading', { name: 'You\'re Ready to Roll!' })).toBeVisible();
+
+  });
+});


### PR DESCRIPTION
## WHY:

Adds e2e-tests for settings page and nav bar buttons

### What has been changed (if possible, add screenshots, gifs, etc. )

Added e2e-tests

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
