### PR TITLE
fix: remove unnecessary options from importEditor

### DIFF
--- a/docs/candidate-app/import-functionality.md
+++ b/docs/candidate-app/import-functionality.md
@@ -71,6 +71,10 @@ The file was modified so that the import button is only visible on certain pages
 
 Originally, the plugin had an option to write the csv directly into the modal. This file was modified so that the text editor is hidden.
 
+### [admin/src/components/ImportModal/components/ImportEditor](../../backend/vaa-strapi/strapi-plugin-import-export-entries/admin/src/components/ImportModal/components/ImportEditor/ImportEditor.js)
+
+Originally, the import modal had an option tab for choosing the id field. This was removed as it is not needed.
+
 ### [admin/src/index.js](../../backend/vaa-strapi/strapi-plugin-import-export-entries/admin/src/index.js)
 
 In this file, the export button and editView options were made hidden.


### PR DESCRIPTION
## WHY:

Import plugin originally had option tab in import editor. This was removed because we don't need it.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
