### PR TITLE
Fix warnings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Backend dependencies
-HOST=0.0.0.0
-PORT=1337
+STRAPI_HOST=0.0.0.0
+STRAPI_PORT=1337
 APP_KEYS="toBeModified1,toBeModified2"
 API_TOKEN_SALT=tobemodified
 # ADMIN_JWT_SECRET and JWT_SECRET has to be different
@@ -23,6 +23,9 @@ SMTP_PASSWORD=""
 MAIL_FROM="candidate-app@example.com"
 MAIL_REPLY_TO="candidate-app@example.com"
 
+# Maildev settings (used only in dev)
+MAILDEV_PORT=1080
+
 # Point to a folder (relative to /backend/vaa-strapi) if you want to load data on initialise. This will only take place if the database contains no Election
 LOAD_DATA_ON_INITIALISE_FOLDER=""
 
@@ -35,3 +38,4 @@ GENERATE_MOCK_DATA_ON_RESTART=false
 # Frontend dependencies
 VITE_BACKEND_URL=http://strapi:1337
 PUBLIC_BACKEND_URL=http://localhost:1337
+FRONTEND_PORT=5173

--- a/backend/vaa-strapi/.env.example
+++ b/backend/vaa-strapi/.env.example
@@ -3,8 +3,8 @@
 ## Use the .env file in the project root when using Docker
 
 # Backend dependencies
-HOST=0.0.0.0
-PORT=1337
+STRAPI_HOST=0.0.0.0
+STRAPI_PORT=1337
 APP_KEYS="toBeModified1,toBeModified2"
 API_TOKEN_SALT=tobemodified
 ADMIN_JWT_SECRET=tobemodified

--- a/backend/vaa-strapi/Dockerfile
+++ b/backend/vaa-strapi/Dockerfile
@@ -27,17 +27,19 @@ FROM strapi as development
 
 ARG NODE_ENV=development
 ENV NODE_ENV=${NODE_ENV}
+ENV STRAPI_DISABLE_REMOTE_DATA_TRANSFER=true
 
 EXPOSE 1337
-RUN yarn build -- --ignore-prompts
+RUN yarn build --ignore-prompts
 CMD yarn dev --ignore-prompts
 
 FROM strapi as production
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
+ENV STRAPI_DISABLE_REMOTE_DATA_TRANSFER=true
 
 EXPOSE 1337
 
-RUN yarn build -- --ignore-prompts
+RUN yarn build --ignore-prompts
 CMD yarn start

--- a/backend/vaa-strapi/config/plugins.ts
+++ b/backend/vaa-strapi/config/plugins.ts
@@ -3,6 +3,9 @@ export default ({env}) => ({
     config: {
       jwt: {
         expiresIn: '4h'
+      },
+      register: {
+        allowedFields: ['candidate']
       }
     }
   },

--- a/backend/vaa-strapi/config/server.ts
+++ b/backend/vaa-strapi/config/server.ts
@@ -1,6 +1,6 @@
 module.exports = ({env}) => ({
-  host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
+  host: env('STRAPI_HOST', '0.0.0.0'),
+  port: env.int('STRAPI_PORT', 1337),
   app: {
     keys: env.array('APP_KEYS')
   }

--- a/backend/vaa-strapi/docker-compose.dev.yml
+++ b/backend/vaa-strapi/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   strapi:
     build:

--- a/backend/vaa-strapi/docker-compose.dev.yml
+++ b/backend/vaa-strapi/docker-compose.dev.yml
@@ -6,11 +6,11 @@ services:
       dockerfile: backend/vaa-strapi/Dockerfile
       target: development
     ports:
-      - 1337:1337
+      - ${STRAPI_PORT}:${STRAPI_PORT}
     restart: always
     environment:
-      HOST: ${HOST}
-      PORT: ${PORT}
+      STRAPI_HOST: ${STRAPI_HOST}
+      STRAPI_PORT: ${STRAPI_PORT}
       APP_KEYS: ${APP_KEYS}
       API_TOKEN_SALT: ${API_TOKEN_SALT}
       ADMIN_JWT_SECRET: ${ADMIN_JWT_SECRET}
@@ -32,7 +32,7 @@ services:
 
       - strapi-uploads:/opt/public/uploads
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:1337/ || exit 1
+      test: wget --no-verbose --tries=1 --spider ${STRAPI_HOST}:${STRAPI_PORT} || exit 1
       interval: 30s
       timeout: 30s
       retries: 3

--- a/backend/vaa-strapi/docker-compose.yml
+++ b/backend/vaa-strapi/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   strapi:
     build:

--- a/backend/vaa-strapi/docker-compose.yml
+++ b/backend/vaa-strapi/docker-compose.yml
@@ -6,11 +6,11 @@ services:
       dockerfile: backend/vaa-strapi/Dockerfile
       target: production
     ports:
-      - '1337:1337'
+      - '${STRAPI_PORT}:${STRAPI_PORT}'
     restart: always
     environment:
-      HOST: ${HOST}
-      PORT: ${PORT}
+      STRAPI_HOST: ${STRAPI_HOST}
+      STRAPI_PORT: ${STRAPI_PORT}
       APP_KEYS: ${APP_KEYS}
       API_TOKEN_SALT: ${API_TOKEN_SALT}
       ADMIN_JWT_SECRET: ${ADMIN_JWT_SECRET}
@@ -25,7 +25,7 @@ services:
       GENERATE_MOCK_DATA_ON_INITIALISE: ${GENERATE_MOCK_DATA_ON_INITIALISE}
       LOAD_DATA_ON_INITIALISE_FOLDER: ${LOAD_DATA_ON_INITIALISE_FOLDER}
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:1337/ || exit 1
+      test: wget --no-verbose --tries=1 --spider ${STRAPI_HOST}:${STRAPI_PORT} || exit 1
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,6 +43,12 @@ services:
       - "127.0.0.1:1080:1080"
     environment:
       - MAILDEV_IP=0.0.0.0
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:1080/healthz || exit 1
+      interval: 30s
+      timeout: 30s
+      retries: 3
+      start_period: 15s
 
 volumes:
   postgres:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,8 +13,8 @@ services:
       file: ./backend/vaa-strapi/docker-compose.dev.yml
       service: strapi
     environment:
-      HOST: ${HOST}
-      PORT: ${PORT}
+      STRAPI_HOST: ${STRAPI_HOST}
+      STRAPI_PORT: ${STRAPI_PORT}
       APP_KEYS: ${APP_KEYS}
       API_TOKEN_SALT: ${API_TOKEN_SALT}
       ADMIN_JWT_SECRET: ${ADMIN_JWT_SECRET}
@@ -40,11 +40,12 @@ services:
   maildev:
     image: maildev/maildev:2.1.0
     ports:
-      - "127.0.0.1:1080:1080"
+      - "${MAILDEV_PORT}:${MAILDEV_PORT}"
     environment:
       - MAILDEV_IP=0.0.0.0
+      - MAILDEV_WEB_PORT=${MAILDEV_PORT}
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:1080/healthz || exit 1
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:${MAILDEV_PORT}/healthz || exit 1
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   frontend:
     extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       file: ./backend/vaa-strapi/docker-compose.yml
       service: strapi
     environment:
-      HOST: ${HOST}
-      PORT: ${PORT}
+      STRAPI_HOST: ${STRAPI_HOST}
+      STRAPI_PORT: ${STRAPI_PORT}
       APP_KEYS: ${APP_KEYS}
       API_TOKEN_SALT: ${API_TOKEN_SALT}
       ADMIN_JWT_SECRET: ${ADMIN_JWT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   frontend:
     extends:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,7 @@ COPY shared /usr/src/app/src/shared
 FROM base as development
 EXPOSE 5173
 
-CMD yarn dev -- --host
+CMD yarn dev --host
 
 FROM base as build
 RUN yarn build

--- a/frontend/docker-compose.dev.yml
+++ b/frontend/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   frontend:
     build:

--- a/frontend/docker-compose.dev.yml
+++ b/frontend/docker-compose.dev.yml
@@ -14,9 +14,9 @@ services:
       - /usr/src/app/android
       - /usr/src/app/ios
     ports:
-      - '5173:5173'
+      - '${FRONTEND_PORT}:${FRONTEND_PORT}'
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:5173/ || exit 1
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:${FRONTEND_PORT}/ || exit 1
       interval: 30s
       timeout: 30s
       retries: 3

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - '80:3000'
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:5173/ || exit 1
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/ || exit 1
       interval: 30s
       timeout: 30s
       retries: 3

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   frontend:
     build:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,10 @@ const config: UserConfig = {
   resolve: {
     preserveSymlinks: true
   },
-  plugins: [sveltekit(), viteTsConfigPaths()]
+  plugins: [sveltekit(), viteTsConfigPaths()],
+  server: {
+    port: Number(process.env.FRONTEND_PORT)
+  }
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@playwright/test": "^1.41.1",
     "@types/node": "^20.11.10",
+    "dotenv": "^16.4.5",
     "husky": "^8.0.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import path from 'path';
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config();
+require('dotenv').config();
 
 export const STORAGE_STATE = path.join(__dirname, 'playwright/.auth/user.json');
 
@@ -32,7 +32,7 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on',
 
-    baseURL: process.env.APP_URL || 'http://localhost:5173',
+    baseURL: process.env.FRONTEND_PORT ? `http://localhost:${process.env.FRONTEND_PORT}` : 'http://localhost:5173',
     storageState: STORAGE_STATE,
   },
 

--- a/tests/register.spec.ts
+++ b/tests/register.spec.ts
@@ -7,7 +7,10 @@ import ariaTranslations from '../frontend/src/lib/i18n/translations/en/aria.json
 import questionsTranslations from '../frontend/src/lib/i18n/translations/en/questions.json';
 import mockQuestions from '../backend/vaa-strapi/src/functions/mockData/mockQuestions.json';
 
-const strapiURL = process.env.STRAPI_URL || "http://localhost:1337";
+const strapiPort = process.env.STRAPI_PORT || "1337";
+const strapiURL = `http://localhost:${strapiPort}`;
+const maildevPort = process.env.MAILDEV_PORT || "1080";
+const maildevURL = `http://localhost:${maildevPort}/#/`;
 const LOCALE = 'en';
 
 const userFirstName = "Alice";
@@ -102,7 +105,7 @@ test.describe.serial("should complete the registration process", () => {
     await page.waitForTimeout(5000);
 
     // Navigate to maildev and open registration link
-    await page.goto("http://localhost:1080/#/");
+    await page.goto(maildevURL);
     await page
       .getByRole("link", { name: `Subject To: ${userEmail}` })
       .first()

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,11 @@
   dependencies:
     undici-types "~5.26.4"
 
+dotenv@^16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
 fsevents@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"


### PR DESCRIPTION
## WHY:

Advances #559 

### What has been changed (if possible, add screenshots, gifs, etc. )

`version` has been removed from docker-compose(.dev).yml files because it was obsolete:
```
WARN[0000] /home/antti/Documents/voting-advice-application/docker-compose.dev.yml: `version` is obsolete
```

Unnecessarry `--` has been removed from yarn commands in Dockerfiles:
```
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
```

`candidate` field has been added to [Strapi plugin config](https://docs.strapi.io/dev-docs/plugins/users-permissions#configuration):
```
warn: Users-permissions registration has defaulted to accepting the following additional user fields during registration: candidate
```

Strapi data transfer feature has been [disabled](https://docs.strapi.io/dev-docs/configurations/environment#strapis-environment-variables) because it is not used:
```
Warning: Missing transfer.token.salt: Data transfer features have been disabled.
Please set transfer.token.salt in config/admin.js (ex: you can generate one using Node with `crypto.randomBytes(16).toString('base64')`)
```

Following warning can't be fixed by us. There is issue about it in the repo of the package but it hasn't been fixed.
```
[vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.
svelte-visibility-change@0.6.0
Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
```

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
