### PR TITLE
refactor: results tab persists state with snapshot

### DIFF
--- a/frontend/src/routes/[[lang=locale]]/(voters)/results/page-stores.ts
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/results/page-stores.ts
@@ -1,6 +1,0 @@
-import {writable} from 'svelte/store';
-
-/**
- * The currently active tab in the results. We want this to persist between opening entity details and returning to the results.
- */
-export const activeTab = writable(0);


### PR DESCRIPTION
## WHY:

Fixes #568 

### What has been changed (if possible, add screenshots, gifs, etc. )

Results tab is persisted with snapshot instead of store.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
