### PR TITLE
refactor: candidate app form inputs

### DIFF
--- a/frontend/src/lib/components/input/Input.svelte
+++ b/frontend/src/lib/components/input/Input.svelte
@@ -1,0 +1,226 @@
+<script lang="ts">
+  import type {HTMLInputTypeAttribute} from 'svelte/elements';
+  import {locale as currentLocale, locales, t} from '$lib/i18n';
+  import {concatClass, getUUID} from '$lib/utils/components';
+  import {Button} from '$lib/components/button';
+  import {Icon} from '$lib/components/icon';
+  import type {InputProps, Key} from './Input.type';
+
+  type $$Props = InputProps;
+
+  export let type: $$Props['type'];
+  export let label: $$Props['label'];
+  export let containerProps: $$Props['containerProps'] = undefined;
+  export let id: $$Props['id'] = getUUID();
+  export let info: $$Props['info'] = undefined;
+  export let locked: $$Props['locked'] = undefined;
+  export let value: $$Props['value'] = undefined;
+  export let onChange: $$Props['onChange'] = undefined;
+  export let placeholder: $$Props['placeholder'] = undefined;
+  export let options: $$Props['options'] = undefined;
+  export let ordered: $$Props['ordered'] = undefined;
+  export let disabled: $$Props['disabled'] = undefined;
+
+  const multilingual = type.endsWith('-multilingual');
+  const multiple = type.endsWith('-multiple');
+  const hasLabelOutside = multiple || type === 'textarea';
+
+  let inputType: HTMLInputTypeAttribute;
+  switch (type) {
+    case 'boolean':
+      inputType = 'checkbox';
+      break;
+    case 'date':
+      inputType = 'date';
+      break;
+    case 'number':
+      inputType = 'number';
+      break;
+    default:
+      inputType = 'text';
+  }
+
+  let isMultilingualVisible = false;
+  let isDisabled: boolean;
+  $: isDisabled = !!(disabled || locked);
+
+  /**
+   * Get a string value for display based on the type of `value` and possible `locale` if multilingual.
+   */
+  function getDisplayValue(value: $$Props['value'], locale?: string): string {
+    locale ??= $currentLocale;
+    // TODO: Return the value as string using the locale or the defaultLocale if multilingual
+  }
+
+  /**
+   * Called internally whenever an input's value changes.
+   */
+  function handleChange(event: {
+    currentTarget: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+  }): void {
+    // TODO: Update value here based on the event target's value and other options
+    // TODO: Maybe add another argument to flag multilingual changes
+    // TODO: For multilingual inputs, iterate over all the locale fields
+    // TODO: For multiple selects add value to the values array
+    value = event.currentTarget.value;
+    handleValueUpdate();
+  }
+
+  /**
+   * Delete an option when multiple can be selected.
+   */
+  function deleteOption(key: Key): void {
+    value = value.filter((v) => v !== key);
+    handleValueUpdate();
+  }
+
+  /**
+   * Called whenever the selected value changes due to any reason
+   */
+  function handleValueUpdate(): void {
+    // TODO: Implement localStorage caching here
+    if (onChange) onChange(value);
+  }
+</script>
+
+<!-- Add containarProps to the outer container and set styles for it -->
+<div {...concatClass(containerProps ?? {}, 'TODO')}>
+  <!-- The label in small caps above the input -->
+  {#if hasLabelOutside}
+    <label class="label" for={id}>{label}</label>
+  {/if}
+
+  <!-- The block of fields -->
+  <div class="flex flex-col gap-2">
+    <!-- Pick the right type of form element -->
+    {#if type === 'textarea'}
+      <div class="field field-vertical">
+        {#if isMultilingualVisible}
+          <label class="small-label" for={id}>{$t(`lang.${$currentLocale}`)}</label>
+        {/if}
+        <textarea
+          disabled={isDisabled}
+          {...concatClass($$restProps, 'TODO')}
+          {id}
+          on:change={handleChange}>
+          {getDisplayValue(value)}
+        </textarea>
+      </div>
+      {#if isMultilingualVisible}
+        {#each $locales.filter((l) => l !== $currentLocale) as locale}
+          <div class="field field-vertical">
+            <label class="small-label" for="{id}-{locale}">{$t(`lang.${locale}`)}</label>
+            <textarea
+              disabled={isDisabled}
+              {...concatClass($$restProps, 'TODO')}
+              id="{id}-{locale}"
+              placeholder="—"
+              on:change={handleChange}>
+              {getDisplayValue(value, locale)}
+            </textarea>
+          </div>
+        {/each}
+      {/if}
+    {:else if type === 'select'}
+      {#if options}
+        <div class="field">
+          <label class="label" for={id}>
+            {#if multiple}
+              <!-- TODO: If all selected, show some other label -->
+              {value.length === 0
+                ? $t('candidateApp.basicInfo.selectFirst')
+                : $t('candidateApp.basicInfo.addAnother')}
+            {:else}
+              {label}
+            {/if}
+          </label>
+          {#if !(multiple && locked)}
+            <select
+              disabled={isDisabled}
+              {...concatClass($$restProps, 'TODO')}
+              {id}
+              on:change={handleChange}>
+              {#each options.filter((o) => !multiple || !value.includes(o.key)) as option}
+                <option value={option.key}>{option.label}</option>
+              {/each}
+            </select>
+          {/if}
+          {#if locked}
+            <Icon name="locked" text={$t('MISSING.locked')} />
+          {/if}
+        </div>
+
+        {#if multiple}
+          <!-- TODO: Enable ordering of options -->
+          {#each value as selectedOption}
+            <div class="field">
+              <div>{selectedOption.label}</div>
+              {#if !locked}
+                <Button
+                  icon="close"
+                  text={$t('MISSING.removeThisOption')}
+                  disabled={isDisabled}
+                  on:click={() => deleteOption(selectedOption.key)} />
+              {/if}
+            </div>
+          {/each}
+        {/if}
+      {:else}
+        <!-- No options defined for select, display some kind of error -->
+        <Error />
+      {/if}
+    {:else}
+      <div class="field">
+        {#if !hasLabelOutside}
+          <label class="label" for={id}>{label}</label>
+        {/if}
+        <input
+          {...concatClass($$restProps, 'TODO')}
+          {id}
+          disabled={isDisabled}
+          type={inputType}
+          value={getDisplayValue(value)}
+          on:change={handleChange} />
+        {#if locked}
+          <Icon name="locked" text={$t('MISSING.locked')} />
+        {/if}
+      </div>
+      {#if isMultilingualVisible}
+        {#each $locales.filter((l) => l !== $currentLocale) as locale}
+          <div class="field">
+            <label class="label" for="{id}-{locale}">{$t(`lang.${locale}`)}</label>
+            <input
+              {...concatClass($$restProps, 'TODO')}
+              id="{id}-{locale}"
+              disabled={isDisabled}
+              placeholder="—"
+              value={getDisplayValue(value, locale)}
+              on:change={handleChange} />
+          </div>
+        {/each}
+      {/if}
+    {/if}
+  </div>
+
+  <!-- Optional elements below the form widgets -->
+
+  {#if info}
+    <div class="text-sm">{info}</div>
+  {/if}
+
+  {#if multilingual}
+    <Button
+      text={isMultilingualVisible ? 'Hide translations' : 'Show translations'}
+      icon="language"
+      on:click={() => (isMultilingualVisible = !isMultilingualVisible)} />
+  {/if}
+</div>
+
+<style lang="postcss">
+  .field {
+    @apply flex h-full items-center justify-between gap-md bg-base-100 first-of-type:rounded-t-lg last-of-type:rounded-b-lg;
+  }
+  .field-vertical {
+    @apply flex-col;
+  }
+</style>

--- a/frontend/src/lib/components/input/Input.type.ts
+++ b/frontend/src/lib/components/input/Input.type.ts
@@ -1,0 +1,109 @@
+import type {SvelteHTMLElements} from 'svelte/elements';
+import type {Photo} from '$lib/types/candidateAttributes';
+
+export type InputProps =
+  | ({
+      type: 'text';
+    } & InputPropsBase<string> &
+      SvelteHTMLElements['input'])
+  | ({
+      type: 'text-multilingual';
+    } & InputPropsBase<LocalizedString> &
+      SvelteHTMLElements['input'])
+  | ({
+      type: 'textarea';
+    } & InputPropsBase<string> &
+      SvelteHTMLElements['textarea'])
+  | ({
+      type: 'textarea-multilingual';
+    } & InputPropsBase<LocalizedString> &
+      SvelteHTMLElements['textarea'])
+  | ({
+      type: 'number';
+    } & InputPropsBase<number> &
+      SvelteHTMLElements['input'])
+  | ({
+      type: 'date';
+    } & InputPropsBase<Date> &
+      SvelteHTMLElements['input'])
+  | ({
+      type: 'boolean';
+    } & InputPropsBase<boolean> &
+      SvelteHTMLElements['input'])
+  | ({
+      type: 'image';
+    } & InputPropsBase<Photo> &
+      SvelteHTMLElements['input'])
+  // TODO: Possibly implement
+  // | ({
+  //   type: 'image-multiple';
+  //   isOrdered?: boolean;
+  // } & InputPropsBase<Array<Photo>> & SvelteHTMLElements['input'])
+  | ({
+      type: 'select';
+      options: Array<Option>;
+    } & InputPropsBase<Key> &
+      SvelteHTMLElements['select'])
+  | ({
+      type: 'select-multiple';
+      options: Array<Option>;
+      isOrdered?: boolean;
+    } & InputPropsBase<Array<Key>> &
+      SvelteHTMLElements['select']);
+
+export type Key = string;
+
+type Option = {
+  key: Key;
+  label: string;
+};
+
+type InputPropsBase<TValue> = {
+  /**
+   * The label to show for the input or group of inputs if `multilingual`.
+   */
+  label: string;
+  /**
+   * Any additional props to be passed to the container element of the input. @default {}
+   */
+  containerProps?: SvelteHTMLElements['div'];
+  /**
+   * The id of the input. If not provided, a unique id will be generated.
+   */
+  id?: string;
+  /**
+   * Additional info displayed below the input.
+   */
+  info?: string;
+  /**
+   * If `locked` the input will be disabled and a lock icon is displayed.
+   */
+  locked?: boolean;
+  /**
+   * Bindable: The value of the input.
+   */
+  value?: TValue;
+  /**
+   * Event handler triggered when the value changes.
+   * @param value The new value of the input.
+   */
+  onChange?: (value: TValue | undefined) => void;
+  /**
+   * If `true` the input's values will be cached in the browser's local storage.
+   */
+  isCached?: boolean;
+  /**
+   * The options to show for a `select` or `select-multiple` input.
+   */
+  options?: Array<Option>;
+  /**
+   * If `true`, enables ordering of the values of a `select-multiple` input.
+   */
+  ordered?: boolean;
+  /**
+   * Works the same way as a normal `input`'s `disabled` attribute.
+   */
+  disabled?: boolean;
+};
+
+export type InputType = InputProps['type'];

--- a/frontend/src/lib/components/input/InputWIP.svelte
+++ b/frontend/src/lib/components/input/InputWIP.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+  import type {HTMLInputTypeAttribute} from 'svelte/elements';
+  import {locale as currentLocale, locales, t} from '$lib/i18n';
+  import {concatClass, getUUID} from '$lib/utils/components';
+  import {Button} from '$lib/components/button';
+  import {Icon} from '$lib/components/icon';
+  import type {InputProps, Key} from './Input.type';
+
+  type $$Props = InputProps;
+
+  export let type: $$Props['type'];
+  export let label: $$Props['label'];
+  export let containerProps: $$Props['containerProps'] = undefined;
+  export let id: $$Props['id'] = getUUID();
+  export let info: $$Props['info'] = undefined;
+  export let locked: $$Props['locked'] = undefined;
+  export let value: $$Props['value'] = undefined;
+  export let onChange: $$Props['onChange'] = undefined;
+  export let placeholder: $$Props['placeholder'] = undefined;
+  export let options: $$Props['options'] = undefined;
+  export let ordered: $$Props['ordered'] = undefined;
+  export let disabled: $$Props['disabled'] = undefined;
+
+  const multilingual = type.endsWith('-multilingual');
+  const multiple = type.endsWith('-multiple');
+  const hasLabelOutside = multiple || type.startsWith('textarea');
+
+  let inputType: HTMLInputTypeAttribute;
+  switch (type) {
+    case 'boolean':
+      inputType = 'checkbox';
+      break;
+    case 'date':
+      inputType = 'date';
+      break;
+    case 'number':
+      inputType = 'number';
+      break;
+    default:
+      inputType = 'text';
+  }
+
+  if (value && inputType === 'date') {
+    const date = new Date(value);
+    if (!isNaN(date.getTime())) {
+      value = date.toISOString().split('T')[0];
+    } else {
+      // Invalid value, use an empty date
+      value = '';
+    }
+  }
+  if (!value && multilingual) {
+    value = Object.fromEntries($locales.map((loc) => [loc, '']));
+  }
+
+  let isMultilingualVisible = false;
+  let isDisabled: boolean;
+  $: isDisabled = !!(disabled || locked);
+
+  /**
+   * Get a string value for display based on the type of `value` and possible `locale` if multilingual.
+   */
+  function getDisplayValue(value: $$Props['value'], locale?: string): string {
+    locale ??= $currentLocale;
+    // TODO: Return the value as string using the locale or the defaultLocale if multilingual
+    if (multilingual) return value[locale] ?? '';
+  }
+
+  /**
+   * Called internally whenever an input's value changes.
+   */
+  function handleChange(
+    event: {
+      currentTarget: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+    },
+    locale?: string
+  ): void {
+    // TODO: Update value here based on the event target's value and other options
+    // TODO: Maybe add another argument to flag multilingual changes
+    // TODO: For multilingual inputs, iterate over all the locale fields
+    // TODO: For multiple selects add value to the values array
+    if (multilingual) {
+      if (locale) value[locale] = event.currentTarget.value;
+    } else {
+      value = event.currentTarget.value;
+    }
+    handleValueUpdate();
+  }
+
+  /**
+   * Delete an option when multiple can be selected.
+   */
+  function deleteOption(key: Key): void {
+    value = value.filter((v) => v !== key);
+    handleValueUpdate();
+  }
+
+  /**
+   * Called whenever the selected value changes due to any reason
+   */
+  function handleValueUpdate(): void {
+    // TODO: Implement localStorage caching here
+    if (onChange) onChange(value);
+  }
+</script>
+
+<!-- Add containarProps to the outer container and set styles for it -->
+<div {...concatClass(containerProps ?? {}, 'w-full')}>
+  <!-- The label in small caps above the input -->
+  {#if hasLabelOutside}
+    <label class="small-label mx-8" for={id}>{label}</label>
+  {/if}
+
+  <!-- The block of fields -->
+
+  {#if multilingual}
+    <div class="relative bg-base-100">
+      {#if isMultilingualVisible}
+        <div class="m-md mb-0">
+          <label for="{id}-{$currentLocale}" class="small-label"
+            >{$t(`lang.${$currentLocale}`)}</label>
+        </div>
+      {/if}
+      <div class="relative bg-base-100">
+        <textarea
+          id="{id}-{$currentLocale}"
+          {placeholder}
+          disabled={isDisabled}
+          class="textarea w-full resize-none px-md py-6 !outline-none disabled:bg-base-100"
+          on:change={(e) => handleChange(e, $currentLocale)}
+          rows="4">{getDisplayValue(value, $currentLocale)}</textarea>
+        {#if locked}
+          <div class="absolute bottom-0 right-0 m-md">
+            <Icon name="locked" class="my-auto flex-shrink-0 text-secondary" />
+          </div>
+        {/if}
+      </div>
+    </div>
+    {#if isMultilingualVisible}
+      {#each $locales.filter((loc) => loc !== $currentLocale) as locale}
+        <div class="relative bg-base-100">
+          <div class="m-md mb-0">
+            <label for="{id}-{locale}" class="small-label">{$t(`lang.${locale}`)}</label>
+          </div>
+          <textarea
+            id="{id}-{locale}"
+            {placeholder}
+            disabled={isDisabled}
+            class="textarea w-full resize-none px-md py-6 !outline-none disabled:bg-base-100"
+            on:change={(e) => handleChange(e, locale)}
+            rows="4"
+            bind:value={value[locale]} />
+          {#if locked}
+            <div class="absolute bottom-0 right-0 m-md">
+              <Icon name="locked" class="my-auto flex-shrink-0 text-secondary" />
+            </div>
+          {/if}
+        </div>
+      {/each}
+    {/if}
+  {/if}
+
+  {#if type === 'boolean' || type === 'text' || type === 'number' || type === 'date'}
+    <div
+      class="my-6 flex h-full w-full items-center justify-between gap-2 overflow-hidden rounded-lg bg-base-100">
+      <label
+        class="label-sm label pointer-events-none mx-6 my-2 whitespace-nowrap text-secondary"
+        for={id}>
+        {label}
+      </label>
+      <div class="flex w-full justify-end pr-6">
+        {#if type === 'boolean'}
+          <input
+            type="checkbox"
+            {id}
+            disabled={isDisabled}
+            class="toggle toggle-primary"
+            bind:checked={value}
+            on:change={handleChange}
+            {placeholder} />
+        {:else if type === 'text'}
+          <input
+            type="text"
+            disabled={isDisabled}
+            {id}
+            bind:value
+            on:change={handleChange}
+            {placeholder}
+            class="input input-sm input-ghost flex w-full justify-end pr-2 text-right disabled:border-none disabled:bg-base-100" />
+        {:else if type === 'number'}
+          <input
+            type="number"
+            disabled={isDisabled}
+            {id}
+            bind:value
+            on:change={handleChange}
+            {placeholder}
+            class="input input-sm input-ghost flex w-full justify-end pr-2 text-right disabled:border-none disabled:bg-base-100" />
+        {:else if type === 'date'}
+          <input
+            type="date"
+            disabled={isDisabled}
+            {id}
+            min="1800-01-01"
+            max={new Date().toISOString().split('T')[0]}
+            bind:value
+            on:change={handleChange}
+            {placeholder}
+            class="input input-sm input-ghost flex w-full justify-end pr-2 text-right disabled:border-none disabled:bg-base-100" />
+        {/if}
+        {#if locked}
+          <Icon name="locked" class="my-auto flex-shrink-0 text-secondary" />
+        {/if}
+      </div>
+    </div>
+  {/if}
+</div>
+
+<!-- Optional elements below the form widgets -->
+
+{#if info}
+  <div class="mx-8 text-sm text-secondary">{info}</div>
+{/if}
+
+{#if multilingual}
+  <Button
+    text={isMultilingualVisible ? 'Hide translations' : 'Show translations'}
+    icon="language"
+    on:click={() => (isMultilingualVisible = !isMultilingualVisible)} />
+{/if}
+
+<style lang="postcss">
+  .field {
+    @apply flex h-full items-center justify-between gap-md bg-base-100 first-of-type:rounded-t-lg last-of-type:rounded-b-lg;
+  }
+  .field-vertical {
+    @apply flex-col;
+  }
+</style>

--- a/frontend/src/routes/[[lang=locale]]/_test/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/_test/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import InputWIP from '$lib/components/input/InputWIP.svelte';
+  import {BasicPage} from '$lib/templates/basicPage';
+
+  function onChange(value: Date | undefined) {
+    console.log('New value:', value);
+  }
+</script>
+
+<BasicPage title="Test" mainClass="bg-base-200">
+  <div class="w-full">
+    <InputWIP type="boolean" label="Boolean" info="This is info" />
+    <InputWIP type="number" label="Locked number" locked={true} value="123" />
+    <InputWIP type="text" label="Text" placeholder="This is placeholder :-)" />
+    <InputWIP type="date" label="Date" {onChange} value="lörs" />
+    <InputWIP type="text-multilingual" label="Multilingual" locked={false} />
+  </div>
+</BasicPage>


### PR DESCRIPTION
## WHY:

- Fixes #319 
- Fixes #557

### What has been changed (if possible, add screenshots, gifs, etc. )

Refactors the multitude of Candidate App components currently handling input fields into reusable, generic components.

Currently, only contains a draft in principle of a common `Input` component for handling all field types.

## Check off each of the following tasks as they are completed

- [ ] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [ ] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
