### PR TITLE
feat: Vertical layout for candidate text answers

### DIFF
--- a/frontend/src/lib/components/entityDetails/EntityInfo.svelte
+++ b/frontend/src/lib/components/entityDetails/EntityInfo.svelte
@@ -70,7 +70,7 @@ Used to show an entity's basic info in an `EntityDetails` component.
       {#if nonLinkQuestions.length}
         {#each nonLinkQuestions as question}
           {#if $settings.entityDetails.showMissingAnswers[entityType] || getAnswer(entity, question) != null}
-            <InfoItem label={question.text}>
+            <InfoItem label={question.text} vertical={question.type === 'text'}>
               <InfoAnswer {entity} {question} />
             </InfoItem>
           {/if}

--- a/frontend/src/lib/components/entityDetails/InfoItem.svelte
+++ b/frontend/src/lib/components/entityDetails/InfoItem.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   /** The info label */
   export let label: string;
+  /** The info layout mode */
+  export let vertical = false;
 </script>
 
 <!--
@@ -10,6 +12,7 @@ Used to show a label-content pair in a Candidate's basic information.
 ### Properties
 
 - `label`: the label of the information
+- `vertical`: layout mode for the item
 
 ### Slots
 
@@ -24,10 +27,25 @@ Used to show a label-content pair in a Candidate's basic information.
 ```
 -->
 
-<div class="infoItem grid grid-flow-col grid-cols-[min-content_auto] justify-start gap-md">
+<div class="grid justify-start gap-md {vertical ? 'vertical-grid' : 'horizontal-grid'}">
   <!-- pt-[0.3rem] matches the baselines of the small label and the content text -->
-  <div class="small-label w-min min-w-[7rem] pt-[0.3rem] text-left align-top">{label}</div>
+  <div
+    class="test-label small-label pt-[0.3rem] text-left align-top {vertical
+      ? 'w-max'
+      : 'min-w-[10rem]'}">
+    {label}
+  </div>
   <div class="overflow-hidden align-top">
     <slot />
   </div>
 </div>
+
+<style lang="postcss">
+  .vertical-grid {
+    @apply grid-flow-row grid-rows-[min-content_auto] pb-8;
+  }
+
+  .horizontal-grid {
+    @apply grid-flow-col grid-cols-[min-content_auto];
+  }
+</style>


### PR DESCRIPTION
## WHY:

Fixes [Issue link](https://github.com/orgs/OpenVAA/projects/7?pane=issue&itemId=69315433)

### What has been changed (if possible, add screenshots, gifs, etc. )

For answers to questions with "text" type:

- we use vertical layout (as in "no columns but rows") now.
- label has unlimited width to compliment / benefit from the vertical layout.
- the vertical layout item got extra bottom padding to separate itself from the following horizontal items visually.

I also increased the column width for all labels - as of now the answers column is supposed to contain only short text and the labels can benefit from some extra width for readability.


<img width="1710" alt="Screenshot 2024-08-14 at 17 00 49" src="https://github.com/user-attachments/assets/e0b34701-e54e-457a-add1-31d473bfef5f">


## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [x] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [x] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
