### PR TITLE
fix: Docker hot reloading for frontend

### DIFF
--- a/frontend/docker-compose.dev.yml
+++ b/frontend/docker-compose.dev.yml
@@ -6,13 +6,13 @@ services:
       target: development
     volumes:
       # Creating this volume will make Docker update changes from local automatically
-      - ./:/usr/src/app
+      - ./:/opt/frontend
       # Mark these as volumes so they get ignored
-      - /usr/src/app/node_modules
-      - /usr/src/app/.svelte-kit
-      - /usr/src/app/.vite
-      - /usr/src/app/android
-      - /usr/src/app/ios
+      - /opt/frontend/node_modules
+      - /opt/frontend/.svelte-kit
+      - /opt/frontend/.vite
+      - /opt/frontend/android
+      - /opt/frontend/ios
     ports:
       - '${FRONTEND_PORT}:${FRONTEND_PORT}'
     healthcheck:


### PR DESCRIPTION
## WHY:

Fixes Docker hot reloading for the frontend by setting the correct path to sources for the volumes.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [x] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [x] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
