### PR TITLE
fix: various small fixes

### DIFF
--- a/frontend/src/lib/components/entityCard/EntityCard.svelte
+++ b/frontend/src/lib/components/entityCard/EntityCard.svelte
@@ -204,7 +204,8 @@ In nested cards, the layout and rendering of contents varies from that of a pare
 
     <!-- Subentities -->
     {#if subcards}
-      <div class="mt-md grid gap-lg">
+      <!-- TODO: Svelte 5: this currently leaves an unseemly empty gap even if there's no content, because the tag will still contain whitespace. With Svelte 5, this is supposed to be automatically fixed. -->
+      <div class="mt-md grid gap-lg empty:mt-0">
         {#each subcards.slice(0, showAllSubcards ? undefined : maxSubcards) as ecProps}
           <svelte:self context="subcard" {...concatClass(ecProps, 'offset-border')} />
         {/each}
@@ -225,6 +226,7 @@ In nested cards, the layout and rendering of contents varies from that of a pare
         {/if}
       </div>
     {/if}
+
     <slot />
   </article>
 </EntityCardAction>

--- a/frontend/src/lib/i18n/README.md
+++ b/frontend/src/lib/i18n/README.md
@@ -27,6 +27,10 @@ type Translation = {
 
 Translations keys contain the name of the file as the first part, e.g. `error.404` for the key `404` in `error.json` or `candidateApp.basicInfo.disclaimer` for `disclaimer` in `candidateApp.basicInfo.json`.
 
+### Special characters
+
+You should not use special characters, e.g. `'\n'`, in the translations, because their backslashes will be escaped when translations are imported.
+
 ### File organisation
 
 Translations are spread into files such that:

--- a/frontend/src/lib/i18n/translations/en/about.json
+++ b/frontend/src/lib/i18n/translations/en/about.json
@@ -1,5 +1,5 @@
 {
-  "content": "<p>The Election Compass works by comparing the opinions you enter to those given by {candidatePlural} and {partyPlural}. The results are given a match score, which is the percentage of how closely you agree with them.</p>\\n<ul>\\n<li>A score of 100 means that you agree completely on all the questions you have answered.</li>\\n<li>A score of 0 means that you disagree on all of the questions.</li>\\n<li>A score between these two extremes means you agree on some questions and disagree on others.</li>\\n</ul>",
+  "content": "<p>The Election Compass works by comparing the opinions you enter to those given by {candidatePlural} and {partyPlural}. The results are given a match score, which is the percentage of how closely you agree with them.</p> <ul> <li>A score of 100 means that you agree completely on all the questions you have answered.</li> <li>A score of 0 means that you disagree on all of the questions.</li> <li>A score between these two extremes means you agree on some questions and disagree on others.</li> </ul>",
   "feedback": {
     "title": "Feedback"
   },

--- a/frontend/src/lib/i18n/translations/fi/about.json
+++ b/frontend/src/lib/i18n/translations/fi/about.json
@@ -1,5 +1,5 @@
 {
-  "content": "<p>Vaalikone vertaa sinun mielipiteitäsi niihin, jotka {candidatePlural} ja {partyPlural} ovat ilmoittaneet samoihin kysymyksiin. Vastaamisen jälkeen näille lasketaan sopivuustulos, joka osoittaa, kuinka paljon olette samaa mieltä.</p>\\n<ul>\\n<li>Tulos 100 tarkoittaa, että olette täysin samaa mieltä kysymyksistä, joihin olet vastannut.</li>\\n<li>Tulos 0 tarkoittaa, että olette täysin eri mieltä kaikista kysymyksistä, joihin olet vastannut.</li>\\n<li>Tulokset näiden välillä tarkoittavat, että olette joistakin kysymyksistä samaa, joistakin eri mieltä.</li>\\n</ul>",
+  "content": "<p>Vaalikone vertaa sinun mielipiteitäsi niihin, jotka {candidatePlural} ja {partyPlural} ovat ilmoittaneet samoihin kysymyksiin. Vastaamisen jälkeen näille lasketaan sopivuustulos, joka osoittaa, kuinka paljon olette samaa mieltä.</p> <ul> <li>Tulos 100 tarkoittaa, että olette täysin samaa mieltä kysymyksistä, joihin olet vastannut.</li> <li>Tulos 0 tarkoittaa, että olette täysin eri mieltä kaikista kysymyksistä, joihin olet vastannut.</li> <li>Tulokset näiden välillä tarkoittavat, että olette joistakin kysymyksistä samaa, joistakin eri mieltä.</li> </ul>",
   "feedback": {
     "title": "Palaute"
   },

--- a/frontend/src/lib/utils/filters.ts
+++ b/frontend/src/lib/utils/filters.ts
@@ -50,7 +50,7 @@ export function buildCandidateFilters(infoQuestions: QuestionProps[], parties: P
           keyProperty: 'id',
           labelProperty: 'name',
           objects: parties,
-          name: t.get('components.entityFilters.titles.party')
+          name: t.get('common.party.singular')
         },
         locale.get()
       )

--- a/frontend/src/lib/utils/matching/LikertQuestion.ts
+++ b/frontend/src/lib/utils/matching/LikertQuestion.ts
@@ -11,9 +11,9 @@ export class LikertQuestion extends OrdinalQuestion {
     this.category = category;
   }
 
-  normalizeValue(value: number): CoordinateOrMissing {
+  normalizeValue(value: number | undefined): CoordinateOrMissing {
     // The current frontend implemenation of questions uses numbers for choice keys
-    return super.normalizeValue(`${value}`);
+    return super.normalizeValue(Number.isFinite(value) ? `${value}` : undefined);
   }
 }
 /**

--- a/frontend/tools/editTranslations/editTranslations.ts
+++ b/frontend/tools/editTranslations/editTranslations.ts
@@ -8,6 +8,7 @@ import {readdir} from 'fs/promises';
  * ### NB
  *
  * `replaceKeys` will only replace old translation keys with new ones in Svelte files in the frontend src folder. This could be easily extended to also cover keys used in the e2e tests in /tests.
+ * You should not use escape characters in the translations, because their backslashes will be escaped when translations are imported.
  *
  * ### TSV Format
  *


### PR DESCRIPTION
## WHY:

Fixes some small issues encountered when working on the settings refactoring.

### What has been changed

- EntityCard spacing when subcards are empty. Removes some margin when the subcards `div` is empty, although due to
whitespace issues this will only have effect with Svelte 5.
- Remove line breaks from translations. Line breaks (and other special characters) cause problems when exporting
and reimporting translations, because the backslashes get escaped. Removes these from the existing translations and updates docs.
- Fix missing party filter translation. Change the party filter name translation to just the party term.
- Fix undefined values in Likert question matching. Properly returns the `undefined` value instead of a `'undefined'` string if the value is missing.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?

**Clean up your git commit history before submitting the pull request!**
