### PR TITLE
build: global edits to `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-# avoid uploading node_modules to the container
-backend/vaa-strapi/node_modules
-frontend/node_modules
+# Avoid uploading node_modules or module builds to the container because we install and build everything there
+**/node_modules
+**/build


### PR DESCRIPTION
Adds `node_modules` and `build` as global patterns to `.dockerignore` because we always build the modules afresh.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have tested my changes using keyboard navigation and screen-reading
- [ ] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?
- [x] I have cleaned up the commit history and checked the commits follow [the guidelines](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/CONTRIBUTING.md#commit-your-update)