### PR TITLE
feat: add `LayoutContext` option for hiding the nav menu

### DIFF
--- a/frontend/src/lib/contexts/layout/layoutContext.ts
+++ b/frontend/src/lib/contexts/layout/layoutContext.ts
@@ -5,7 +5,7 @@ import { tweened } from 'svelte/motion';
 import { writable } from 'svelte/store';
 import { type DeepPartial, mergeSettings } from '$lib/utils/merge';
 import { stackedStore } from '../utils/stackedStore';
-import type { LayoutContext, PageStyles, TopBarSettings } from './layoutContext.type';
+import type { LayoutContext, NavigationSettings, PageStyles, TopBarSettings } from './layoutContext.type';
 
 const CONTEXT_KEY = Symbol();
 
@@ -27,6 +27,10 @@ export const DEFAULT_PAGE_STYLES: PageStyles = {
   }
 } as const;
 
+export const DEFAULT_NAVIGATION_SETTINGS: NavigationSettings = {
+  hide: false
+} as const;
+
 /**
  * Initialize and return the context. This must be called before `getLayoutContext()` and cannot be called twice.
  * @returns The context object
@@ -44,6 +48,11 @@ export function initLayoutContext(): LayoutContext {
     (current, value) => [...current, mergeSettings(current[current.length - 1], value)]
   );
 
+  const navigationSettings = stackedStore<NavigationSettings, DeepPartial<NavigationSettings>>(
+    DEFAULT_NAVIGATION_SETTINGS,
+    (current, value) => [...current, mergeSettings(current[current.length - 1], value)]
+  );
+
   const progress = {
     max: writable(0),
     current: tweened(0, {
@@ -58,7 +67,8 @@ export function initLayoutContext(): LayoutContext {
     pageStyles,
     topBarSettings,
     progress,
-    navigation
+    navigation,
+    navigationSettings
   });
 }
 
@@ -72,9 +82,11 @@ export function getLayoutContext(onDestroy: (fn: () => unknown) => void) {
   const ctx = getContext<LayoutContext>(CONTEXT_KEY);
   const indexPageStyle = ctx.pageStyles.getLength() - 1;
   const indexTopBar = ctx.topBarSettings.getLength() - 1;
+  const indexNavigation = ctx.navigationSettings.getLength() - 1;
   onDestroy(() => {
     ctx.pageStyles.revert(indexPageStyle);
     ctx.topBarSettings.revert(indexTopBar);
+    ctx.navigationSettings.revert(indexNavigation);
   });
   return ctx;
 }

--- a/frontend/src/lib/contexts/layout/layoutContext.type.ts
+++ b/frontend/src/lib/contexts/layout/layoutContext.type.ts
@@ -21,6 +21,11 @@ export type LayoutContext = {
    * A context object that should contain a callback for closing the navigation menu.
    */
   navigation: Navigation;
+  /**
+   * A store containing navigation settings.
+   * NB. This is not contained under `navigation` for easier store access.
+   */
+  navigationSettings: StackedStore<NavigationSettings, DeepPartial<NavigationSettings>>;
 };
 
 export interface PageStyles {
@@ -54,4 +59,14 @@ interface Navigation {
    * A function that closes the navigation drawer.
    */
   close?: () => void;
+}
+
+/**
+ * A store containing navigation settings.
+ */
+export interface NavigationSettings {
+  /**
+   * Whether to hide the nav menu and the button opening it. Default is `false`.
+   */
+  hide?: boolean;
 }

--- a/frontend/src/routes/[[lang=locale]]/Header.svelte
+++ b/frontend/src/routes/[[lang=locale]]/Header.svelte
@@ -7,6 +7,10 @@ Defines the global app header.
 ### Dynamic component
 
 Accesses `AppContext` and renders the dynamic `Banner` component.
+
+### Settings
+
+- `headerStyle`: affects the background color of the header.
 -->
 
 <script lang="ts">
@@ -24,16 +28,14 @@ Accesses `AppContext` and renders the dynamic `Banner` component.
 
   const { appSettings, darkMode, t } = getAppContext();
 
-  const { topBarSettings, progress } = getLayoutContext(onDestroy);
+  const { navigationSettings, progress, topBarSettings } = getLayoutContext(onDestroy);
 
   const currentProgress = progress.current;
   const maxProgress = progress.max;
 
-  const headerStyle = $appSettings.headerStyle;
-
   let bgColor: string | undefined;
   $: {
-    const mode = $darkMode ? headerStyle.dark : headerStyle.light;
+    const mode = $darkMode ? $appSettings.headerStyle.dark : $appSettings.headerStyle.light;
     bgColor = $topBarSettings.imageSrc ? mode.overImgBgColor : mode.bgColor;
   }
 
@@ -60,8 +62,8 @@ Accesses `AppContext` and renders the dynamic `Banner` component.
   class:prominent-top-bar-with-background={$topBarSettings.imageSrc}
   class:top-bar={!$topBarSettings.imageSrc}
   style:--image={$topBarSettings.imageSrc && `url(${$topBarSettings.imageSrc})`}
-  style:--background-size={$topBarSettings.imageSrc && headerStyle.imgSize}
-  style:--background-position={$topBarSettings.imageSrc && headerStyle.imgPosition}>
+  style:--background-size={$topBarSettings.imageSrc && $appSettings.headerStyle.imgSize}
+  style:--background-position={$topBarSettings.imageSrc && $appSettings.headerStyle.imgPosition}>
   {#if $topBarSettings.progress === 'show'}
     <progress
       class="progress progress-primary absolute left-0 top-0 h-2"
@@ -77,8 +79,9 @@ Accesses `AppContext` and renders the dynamic `Banner` component.
       aria-expanded={isDrawerOpen}
       aria-controls={menuId}
       aria-label={$t('common.openMenu')}
+      disabled={$navigationSettings.hide}
       class="btn btn-ghost drawer-button flex cursor-pointer items-center gap-md text-neutral">
-      <Icon name="menu" />
+      <Icon name="menu" class={$navigationSettings.hide ? 'hidden' : undefined} />
       <!-- inverse={invertLogo} -->
       <AppLogo inverse={false} aria-hidden="true" />
     </button>

--- a/frontend/src/routes/[[lang=locale]]/Layout.svelte
+++ b/frontend/src/routes/[[lang=locale]]/Layout.svelte
@@ -39,6 +39,8 @@ Defines the outer layout for the application, including the header and menu.
   ////////////////////////////////////////////////////////////////////
 
   const { startEvent, t } = getAppContext();
+  const { pageStyles, navigation, navigationSettings } = getLayoutContext(onDestroy);
+  navigation.close = closeDrawer;
 
   let drawerOpenElement: HTMLButtonElement | undefined;
 
@@ -47,6 +49,7 @@ Defines the outer layout for the application, including the header and menu.
    * to toggle it back when using keyboard navigation.
    */
   function openDrawer() {
+    if ($navigationSettings.hide) return;
     isDrawerOpen = true;
     // We need a small timeout for drawerCloseButton to be focusable
     setTimeout(() => document.getElementById('drawerCloseButton')?.focus(), 50);
@@ -61,12 +64,6 @@ Defines the outer layout for the application, including the header and menu.
     isDrawerOpen = false;
     drawerOpenElement?.focus();
   }
-
-  /**
-   * Init the context for layout changes.
-   */
-  const { pageStyles, navigation } = getLayoutContext(onDestroy);
-  navigation.close = closeDrawer;
 
   /** We use `videoHeight` and `videoWidth` as proxies to check for the presence of content in the `video` slot. Note that we cannot merely check if the slot is provided, because it might be empty. */
   // let videoHeight = 0;
@@ -87,6 +84,7 @@ Defines the outer layout for the application, including the header and menu.
     bind:checked={isDrawerOpen}
     type="checkbox"
     class="drawer-toggle"
+    disabled={$navigationSettings.hide}
     tabindex="-1"
     aria-hidden="true"
     aria-label={$t('common.openCloseMenu')} />


### PR DESCRIPTION
## WHY:

Fixes #677 

### What has been changed (if possible, add screenshots, gifs, etc. )

Add an option to hide the navigation menu for use on, e.g., the pre-registration route.

To test, add this code to any route:

```ts
  import { getLayoutContext } from '$lib/contexts/layout';
  import { onDestroy } from 'svelte';
  const { navigationSettings } = getLayoutContext(onDestroy);
  navigationSettings.push({ hide: true});
```

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [x] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have tested my changes using keyboard navigation and screen-reading
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?
- [x] I have cleaned up the commit history and checked the commits follow [the guidelines](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/CONTRIBUTING.md#commit-your-update)