### PR TITLE
feat: add Cancel registration button to `Banner`

### DIFF
--- a/frontend/src/lib/contexts/layout/layoutContext.ts
+++ b/frontend/src/lib/contexts/layout/layoutContext.ts
@@ -12,11 +12,13 @@ const CONTEXT_KEY = Symbol();
 export const DEFAULT_TOP_BAR_SETTINGS: TopBarSettings = {
   progress: 'hide',
   actions: {
-    return: 'hide',
-    help: 'hide',
+    cancel: 'hide',
+    cancelButtonLabel: '',
     feedback: 'hide',
+    help: 'hide',
     logout: 'hide',
     results: 'hide',
+    return: 'hide',
     returnButtonLabel: ''
   }
 };

--- a/frontend/src/lib/contexts/layout/layoutContext.type.ts
+++ b/frontend/src/lib/contexts/layout/layoutContext.type.ts
@@ -5,7 +5,7 @@ import type { StackedStore } from '../utils/stackedStore';
 
 export type LayoutContext = {
   /**
-   * A store containing top bar actions settings.
+   * A store containing top bar actions settings. When showing some buttons, make sure to provide a callback if they define one.
    */
   topBarSettings: StackedStore<TopBarSettings, DeepPartial<TopBarSettings>>;
   /**
@@ -29,11 +29,13 @@ export interface PageStyles {
   };
 }
 
-type TopBarAction = 'return' | 'help' | 'feedback' | 'results' | 'logout';
+type TopBarAction = 'cancel' | 'feedback' | 'help' | 'logout' | 'results' | 'return';
 
 type TopBarActionsSettings = {
   [action in TopBarAction]: 'hide' | 'show';
 } & {
+  cancelButtonLabel: string;
+  cancelButtonCallback?: () => void;
   returnButtonLabel: string;
   returnButtonCallback?: () => void;
 };

--- a/frontend/src/routes/[[lang=locale]]/Banner.svelte
+++ b/frontend/src/routes/[[lang=locale]]/Banner.svelte
@@ -4,6 +4,10 @@
 
 Contains the secondary action buttons in the header.
 
+### TODO
+
+Allow layouts to insert arbitrary content in the header and make this a static component [Svelte 5].
+
 ### Dynamic component
 
 Accesses `AppContext` and optionally `VoterContext`.
@@ -70,8 +74,18 @@ Accesses `AppContext` and optionally `VoterContext`.
       class="!text-neutral"
       variant="icon"
       icon="close"
-      text={$topBarSettings.actions.returnButtonLabel}
-      on:click={$topBarSettings.actions.returnButtonCallback || (() => goto($getRoute('Home')))} />
+      text={$topBarSettings.actions.returnButtonLabel || $t('common.return')}
+      on:click={$topBarSettings.actions.returnButtonCallback ||
+        (() => goto($appType === 'voter' ? $getRoute('Home') : $getRoute('CandAppHome')))} />
+  {/if}
+
+  {#if $topBarSettings.actions.cancel === 'show' && $topBarSettings.actions.cancelButtonCallback}
+    <Button
+      class="!text-warning"
+      variant="icon"
+      icon="close"
+      text={$topBarSettings.actions.cancelButtonLabel || $t('common.cancel')}
+      on:click={$topBarSettings.actions.cancelButtonCallback} />
   {/if}
 </div>
 
@@ -81,6 +95,6 @@ Accesses `AppContext` and optionally `VoterContext`.
   :global(.vaa-basicPage-actions > button:not([disabled])),
   :global(.vaa-basicPage-actions > * > button:not([disabled])) {
     /* !text is valid class prefix */
-    @apply !text-[var(--headerIcon-color)];
+    @apply text-[var(--headerIcon-color)];
   }
 </style>


### PR DESCRIPTION
## WHY:

Fixes #678 

### What has been changed

Add a `cancel` action to `Banner` which can be used to execute an
arbitrary callback, e.g., to cancel the pre-registration process.

The button is very similar to `return` but is a distinct one, because
the former offers some (now updated) default actions and its behaviour
may change in the future.

To test, add the following on any route:

```ts
  import { getLayoutContext } from '$lib/contexts/layout';
  import { onDestroy } from 'svelte';
  const { topBarSettings } = getLayoutContext(onDestroy);
  topBarSettings.push({
    actions: {
      cancel: 'show',
      cancelButtonLabel: $t('common.cancel'),
      cancelButtonCallback: function() {
        console.error('CANCEL!')
      },
    }
  });
```

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [x] I have tested my changes using keyboard navigation and screen-reading
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?
- [x] I have cleaned up the commit history and checked the commits follow [the guidelines](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/CONTRIBUTING.md#commit-your-update)