### PR TITLE
feat: Make performance-optimized alternative to /api/nominations and /api/question-categories

### DIFF
--- a/backend/vaa-strapi/src/api/nomination/controllers/nomination.ts
+++ b/backend/vaa-strapi/src/api/nomination/controllers/nomination.ts
@@ -4,4 +4,233 @@
 
 import { factories } from '@strapi/strapi';
 
-export default factories.createCoreController('api::nomination.nomination');
+export default factories.createCoreController('api::nomination.nomination', ({ strapi }) => ({
+  /**
+   * Fetches nominations with optional filtering by election and constituency.
+   *
+   * This function provides a performance-optimized alternative to the default Strapi `/api/nominations` endpoint.
+   *
+   * ### Filters
+   * The function accepts an optional `filters` object to refine the query:
+   *
+   * ```ts
+   * filters = {
+   *   election?: {
+   *     documentId?: {
+   *       $in?: string[];
+   *     };
+   *   };
+   *   constituency?: {
+   *     documentId?: {
+   *       $in?: string[];
+   *     };
+   *   };
+   * };
+   * ```
+   *
+   * ### Populated Relations
+   * The following related entities are automatically populated:
+   *
+   * ```ts
+   * populate = {
+   *   constituency: true,
+   *   election: true,
+   *   candidate: {
+   *     populate: {
+   *       image: true,
+   *       party: true
+   *     }
+   *   },
+   *   party: {
+   *     populate: { image: true }
+   *   }
+   * };
+   * ```
+   *
+   * ### Pagination
+   *
+   * Not supported.
+   */
+  async withRelations(ctx) {
+    const query = ctx.query as {
+      filters?: {
+        election?: {
+          documentId?: {
+            $in?: Array<string>;
+          };
+        };
+        constituency?: {
+          documentId?: {
+            $in?: Array<string>;
+          };
+        };
+      };
+    };
+
+    function sqlInFilter($in: Array<string> = []) {
+      const values = $in.filter(Boolean);
+      const enabled = Boolean(values.length);
+      return {
+        enabled,
+        values: enabled ? values : [''] // IN cannot be empty.
+      };
+    }
+
+    const electionSqlInFilter = sqlInFilter(query.filters?.election?.documentId?.$in);
+    const constituencySqlInFilter = sqlInFilter(query.filters?.constituency?.documentId?.$in);
+
+    try {
+      const { rows: nominations } = await strapi.db.connection.raw<{ rows: Array<{ data: object }> }>(
+        `
+        with _elections as (
+          select
+            elections.id,
+            json_build_object(
+              'id', elections.id,
+              'documentId', elections.document_id,
+              'electionStartDate', elections.election_start_date,
+              'electionDate', elections.election_date,
+              'electionType', elections.election_type,
+              'name', elections.name,
+              'shortName', elections.short_name,
+              'info', elections.info,
+              'createdAt', elections.created_at,
+              'updatedAt', elections.updated_at,
+              'publishedAt', elections.published_at
+            ) data
+           from elections
+           where (? = false or elections.document_id in (${electionSqlInFilter.values.map(() => '?').join(',')}))
+        ),
+        _constituencies as (
+          select
+            constituencies.id,
+            json_build_object(
+              'id', constituencies.id,
+              'documentId', constituencies.document_id,
+              'name', constituencies.name,
+              'shortName', constituencies.short_name,
+              'info', constituencies.info,
+              'keywords', constituencies.keywords,
+              'createdAt', constituencies.created_at,
+              'updatedAt', constituencies.updated_at,
+              'publishedAt', constituencies.published_at
+            ) data
+          from constituencies
+          where (? = false or constituencies.document_id in (${constituencySqlInFilter.values.map(() => '?').join(',')}))
+        ),
+        _images as (
+          select
+            files_related_mph.related_id,
+            json_build_object(
+              'id', files.id,
+              'documentId', files.document_id,
+              'name', files.name,
+              'alternativeText', files.alternative_text,
+              'caption', files.caption,
+              'width', files.width,
+              'height', files.height,
+              'formats', files.formats,
+              'hash', files.hash,
+              'ext', files.ext,
+              'mime', files.mime,
+              'size', files.size,
+              'url', files.url,
+              'previewUrl', files.preview_url,
+              'provider', files.provider,
+              'provider_metadata', files.provider_metadata,
+              'createdAt', files.created_at,
+              'updatedAt', files.updated_at,
+              'publishedAt', files.published_at
+            ) data
+          from files_related_mph
+          join files on files.id = files_related_mph.file_id
+        ),
+        _parties as (
+          select
+            id,
+            json_build_object(
+              'id', parties.id,
+              'documentId', parties.document_id,
+              'color', parties.color,
+              'name', parties.name,
+              'shortName', parties.short_name,
+              'info', parties.info,
+              'colorDark', parties.color_dark,
+              'answers', parties.answers,
+              'createdAt', parties.created_at,
+              'updatedAt', parties.updated_at,
+              'publishedAt', parties.published_at,
+              'image', _images.data
+            ) data
+          from parties
+          left join _images on _images.related_id = parties.id
+        )
+        select
+          json_build_object(
+            'id', nominations.id,
+            'documentId', nominations.document_id,
+            'electionSymbol', nominations.election_symbol,
+            'electionRound', nominations.election_round,
+            'unconfirmed', nominations.unconfirmed,
+            'createdAt', nominations.created_at,
+            'updatedAt', nominations.updated_at,
+            'publishedAt', nominations.published_at,
+            'constituency', _constituencies.data,
+            'election', _elections.data,
+            'candidate', json_build_object(
+              'id', candidates.id,
+              'documentId', candidates.document_id,
+              'firstName', candidates.first_name,
+              'lastName', candidates.last_name,
+              'answers', candidates.answers,
+              'createdAt', candidates.created_at,
+              'updatedAt', candidates.updated_at,
+              'publishedAt', candidates.published_at,
+              'image', candidates_images.data,
+              'party', candidates_parties.data
+            ),
+            'party', nominations_parties.data
+          ) data
+        from nominations
+        -- Election
+        join nominations_election_lnk on nominations_election_lnk.nomination_id = nominations.id
+        join _elections on _elections.id = nominations_election_lnk.election_id
+        -- Constituency
+        join nominations_constituency_lnk on nominations_constituency_lnk.nomination_id = nominations.id
+        join _constituencies on _constituencies.id = nominations_constituency_lnk.constituency_id
+        -- Candidate
+        join nominations_candidate_lnk on nominations_candidate_lnk.nomination_id = nominations.id
+        join candidates on candidates.id = nominations_candidate_lnk.candidate_id
+        left join _images candidates_images on candidates_images.related_id = candidates.id
+        -- Candidate's party
+        left join candidates_party_lnk on candidates_party_lnk.candidate_id = candidates.id
+        left join _parties candidates_parties on candidates_parties.id = candidates_party_lnk.party_id
+        -- Nomination's party
+        left join nominations_party_lnk on nominations_party_lnk.nomination_id = nominations.id
+        left join _parties nominations_parties on nominations_parties.id = nominations_party_lnk.party_id
+        order by nominations.id
+      `,
+        [
+          electionSqlInFilter.enabled,
+          ...electionSqlInFilter.values,
+          constituencySqlInFilter.enabled,
+          ...constituencySqlInFilter.values
+        ]
+      );
+
+      return {
+        data: nominations.map(({ data }) => data),
+        meta: {
+          pagination: {
+            page: 1,
+            pageSize: nominations.length,
+            pageCount: 1,
+            total: nominations.length
+          }
+        }
+      };
+    } catch {
+      ctx.throw(500);
+    }
+  }
+}));

--- a/backend/vaa-strapi/src/api/nomination/controllers/nomination.ts
+++ b/backend/vaa-strapi/src/api/nomination/controllers/nomination.ts
@@ -148,11 +148,9 @@ export default factories.createCoreController('api::nomination.nomination', ({ s
               'shortName', parties.short_name,
               'info', parties.info,
               'colorDark', parties.color_dark,
-              'answers', parties.answers,
-              'image', _images.data
+              'answers', parties.answers
             ) data
           from parties
-          left join _images on _images.related_id = parties.id
         )
         select
           json_build_object(

--- a/backend/vaa-strapi/src/api/nomination/controllers/nomination.ts
+++ b/backend/vaa-strapi/src/api/nomination/controllers/nomination.ts
@@ -86,17 +86,13 @@ export default factories.createCoreController('api::nomination.nomination', ({ s
           select
             elections.id,
             json_build_object(
-              'id', elections.id,
               'documentId', elections.document_id,
               'electionStartDate', elections.election_start_date,
               'electionDate', elections.election_date,
               'electionType', elections.election_type,
               'name', elections.name,
               'shortName', elections.short_name,
-              'info', elections.info,
-              'createdAt', elections.created_at,
-              'updatedAt', elections.updated_at,
-              'publishedAt', elections.published_at
+              'info', elections.info
             ) data
            from elections
            where (? = false or elections.document_id in (${electionSqlInFilter.values.map(() => '?').join(',')}))
@@ -105,15 +101,11 @@ export default factories.createCoreController('api::nomination.nomination', ({ s
           select
             constituencies.id,
             json_build_object(
-              'id', constituencies.id,
               'documentId', constituencies.document_id,
               'name', constituencies.name,
               'shortName', constituencies.short_name,
               'info', constituencies.info,
-              'keywords', constituencies.keywords,
-              'createdAt', constituencies.created_at,
-              'updatedAt', constituencies.updated_at,
-              'publishedAt', constituencies.published_at
+              'keywords', constituencies.keywords
             ) data
           from constituencies
           where (? = false or constituencies.document_id in (${constituencySqlInFilter.values.map(() => '?').join(',')}))
@@ -123,24 +115,15 @@ export default factories.createCoreController('api::nomination.nomination', ({ s
             files_related_mph.related_id,
             json_build_object(
               'id', files.id,
-              'documentId', files.document_id,
               'name', files.name,
               'alternativeText', files.alternative_text,
               'caption', files.caption,
               'width', files.width,
               'height', files.height,
               'formats', files.formats,
-              'hash', files.hash,
               'ext', files.ext,
-              'mime', files.mime,
               'size', files.size,
-              'url', files.url,
-              'previewUrl', files.preview_url,
-              'provider', files.provider,
-              'provider_metadata', files.provider_metadata,
-              'createdAt', files.created_at,
-              'updatedAt', files.updated_at,
-              'publishedAt', files.published_at
+              'url', files.url
             ) data
           from files_related_mph
           join files on files.id = files_related_mph.file_id
@@ -149,7 +132,6 @@ export default factories.createCoreController('api::nomination.nomination', ({ s
           select
             id,
             json_build_object(
-              'id', parties.id,
               'documentId', parties.document_id,
               'color', parties.color,
               'name', parties.name,
@@ -157,9 +139,6 @@ export default factories.createCoreController('api::nomination.nomination', ({ s
               'info', parties.info,
               'colorDark', parties.color_dark,
               'answers', parties.answers,
-              'createdAt', parties.created_at,
-              'updatedAt', parties.updated_at,
-              'publishedAt', parties.published_at,
               'image', _images.data
             ) data
           from parties
@@ -167,25 +146,17 @@ export default factories.createCoreController('api::nomination.nomination', ({ s
         )
         select
           json_build_object(
-            'id', nominations.id,
             'documentId', nominations.document_id,
             'electionSymbol', nominations.election_symbol,
             'electionRound', nominations.election_round,
             'unconfirmed', nominations.unconfirmed,
-            'createdAt', nominations.created_at,
-            'updatedAt', nominations.updated_at,
-            'publishedAt', nominations.published_at,
             'constituency', _constituencies.data,
             'election', _elections.data,
             'candidate', json_build_object(
-              'id', candidates.id,
               'documentId', candidates.document_id,
               'firstName', candidates.first_name,
               'lastName', candidates.last_name,
               'answers', candidates.answers,
-              'createdAt', candidates.created_at,
-              'updatedAt', candidates.updated_at,
-              'publishedAt', candidates.published_at,
               'image', candidates_images.data,
               'party', candidates_parties.data
             ),

--- a/backend/vaa-strapi/src/api/nomination/routes/00-customRoutes.ts
+++ b/backend/vaa-strapi/src/api/nomination/routes/00-customRoutes.ts
@@ -1,5 +1,5 @@
 /**
- * Contains the definitions for the `api::candidate.answers.overwrite/update` and `api::candidate.properties.update` actions.
+ * Contains the definitions for the `api::nomination.nomination.withRelations` getter.
  * NB. The filename starts with zeros so that it is matched before the core routes.
  */
 

--- a/backend/vaa-strapi/src/api/nomination/routes/00-customRoutes.ts
+++ b/backend/vaa-strapi/src/api/nomination/routes/00-customRoutes.ts
@@ -1,0 +1,20 @@
+/**
+ * Contains the definitions for the `api::candidate.answers.overwrite/update` and `api::candidate.properties.update` actions.
+ * NB. The filename starts with zeros so that it is matched before the core routes.
+ */
+
+import type { Core } from '@strapi/strapi';
+
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/nominations/with-relations',
+      handler: 'nomination.withRelations',
+      config: {
+        auth: false,
+        policies: []
+      }
+    } as Core.RouteConfig
+  ]
+};

--- a/backend/vaa-strapi/src/api/question-category/controllers/question-category.ts
+++ b/backend/vaa-strapi/src/api/question-category/controllers/question-category.ts
@@ -3,5 +3,193 @@
  */
 
 import { factories } from '@strapi/strapi';
+//import { validateYupSchema, yup } from '@strapi/utils';
 
-export default factories.createCoreController('api::question-category.question-category');
+/*
+const validateQuery = validateYupSchema(
+  yup.object({
+    filters: yup
+      .object({
+        $or: yup.array(yup.object({})).optional()
+      })
+      .optional()
+  })
+);
+*/
+
+export default factories.createCoreController('api::question-category.question-category', ({ strapi }) => ({
+  /**
+   * Fetches question-categories with optional filtering by election.
+   *
+   * This function provides a performance-optimized alternative to the default Strapi `/api/question-categories` endpoint.
+   *
+   * ### Filters
+   * The function accepts an optional `filters` object to refine the query:
+   *
+   * ```ts
+   * filters = {
+   *   $or: [
+   *     { elections: { documentId: { $in: string[] } },
+   *     { elections: { documentId: { $null: 'true' } } }
+   *   ]
+   * };
+   * ```
+   *
+   * ### Populated Relations
+   * The following related entities are automatically populated:
+   *
+   * ```ts
+   * populate = {
+   *   constituencies: 'true',
+   *   elections: 'true',
+   *   questions: {
+   *     populate: {
+   *       constituencies: 'true',
+   *       questionType: 'true'
+   *     }
+   *   }
+   * };
+   * ```
+   *
+   * ### Pagination
+   *
+   * Not supported.
+   */
+  async withRelations(ctx) {
+    const query = ctx.query as {
+      filters?: {
+        $or?: Array<{ elections: { documentId: { $in: Array<string> } | { $null: 'true' } } }>;
+      };
+    };
+
+    const electionSqlInFilter = {
+      enabled: Boolean(query?.filters?.$or?.some((condition) => '$in' in condition.elections.documentId)),
+      values: query?.filters?.$or?.flatMap((condition) =>
+        '$in' in condition.elections.documentId ? condition.elections.documentId.$in : []
+      )
+    };
+    const electionSqlNullFilter = {
+      enabled: Boolean(query?.filters?.$or?.some((condition) => '$null' in condition.elections.documentId))
+    };
+
+    try {
+      const { rows: questionCategories } = await strapi.db.connection.raw<{ rows: Array<{ data: object }> }>(
+        `
+          with question_categories_constituencies as (
+            select
+              question_categories_constituencies_lnk.question_category_id,
+              json_agg(json_build_object(
+                'documentId', constituencies.document_id,
+                'name', constituencies.name,
+                'shortName', constituencies.short_name,
+                'info', constituencies.info,
+                'keywords', constituencies.keywords
+              ) order by constituencies.id) as constituencies
+            from question_categories_constituencies_lnk
+            join constituencies on constituencies.id = question_categories_constituencies_lnk.constituency_id
+            group by question_categories_constituencies_lnk.question_category_id
+          ),
+          question_categories_elections as (
+            select
+              question_categories_elections_lnk.question_category_id,
+              json_agg(json_build_object(
+                'documentId', elections.document_id,
+                'electionStartDate', elections.election_start_date,
+                'electionDate', elections.election_date,
+                'electionType', elections.election_type,
+                'name', elections.name,
+                'shortName', elections.short_name,
+                'info', elections.info
+              ) order by elections.id) as elections,
+              bool_or(elections.document_id = any(?)) as is_election_document_id_in
+            from question_categories_elections_lnk
+            join elections on elections.id = question_categories_elections_lnk.election_id
+            group by question_categories_elections_lnk.question_category_id
+          ),
+          questions_constituencies as (
+            select
+              questions_constituencies_lnk.question_id,
+              json_agg(json_build_object(
+                'documentId', constituencies.document_id,
+                'name', constituencies.name,
+                'shortName', constituencies.short_name,
+                'info', constituencies.info,
+                'keywords', constituencies.keywords
+              ) order by constituencies.id) as constituencies
+            from questions_constituencies_lnk
+            join constituencies on constituencies.id = questions_constituencies_lnk.constituency_id
+            group by questions_constituencies_lnk.question_id
+          ),
+          questions_category as (
+            select
+              questions_category_lnk.question_category_id,
+              json_agg(json_build_object(
+                'documentId', questions.document_id,
+                'allowOpen', questions.allow_open,
+                'customData', questions.custom_data,
+                'entityType', questions.entity_type,
+                'fillingInfo', questions.filling_info,
+                'filterable', questions.filterable,
+                'info', questions.info,
+                'order', questions.order,
+                'required', questions.required,
+                'shortName', questions.short_name,
+                'text', questions.text,
+                'questionType', json_build_object(
+                  'documentId', question_types.document_id,
+                  'info', question_types.info,
+                  'name', question_types.name,
+                  'settings', question_types.settings
+                ),
+                'constituencies', coalesce(questions_constituencies.constituencies, '[]'::json)
+              ) order by questions.id) questions
+            from questions_category_lnk
+            join questions on questions.id = questions_category_lnk.question_id
+            left join questions_question_type_lnk on questions_question_type_lnk.question_id = questions.id
+            left join question_types on question_types.id = questions_question_type_lnk.question_type_id
+            left join questions_constituencies on questions_constituencies.question_id = questions.id
+            group by questions_category_lnk.question_category_id
+          )
+          select
+            json_build_object(
+              'documentId', question_categories.document_id,
+              'color', question_categories.color,
+              'colorDark', question_categories.color_dark,
+              'customData', question_categories.custom_data,
+              'info',  question_categories.info,
+              'name', question_categories.name,
+              'order', question_categories.order,
+              'shortName', question_categories.short_name,
+              'type', question_categories.type,
+              'constituencies', coalesce(question_categories_constituencies.constituencies, '[]'::json),
+              'elections', coalesce(question_categories_elections.elections, '[]'::json),
+              'questions', coalesce(questions_category.questions, '[]'::json)
+            ) "data"
+          from question_categories
+          left join question_categories_constituencies on question_categories_constituencies.question_category_id = question_categories.id
+          left join question_categories_elections on question_categories_elections.question_category_id = question_categories.id
+          left join questions_category on questions_category.question_category_id =  question_categories.id
+          where
+            (? = false or question_categories_elections.is_election_document_id_in) or
+            (? = false or question_categories_elections.elections is null)
+          order by question_categories.id
+        `,
+        [electionSqlInFilter.values, electionSqlInFilter.enabled, electionSqlNullFilter.enabled]
+      );
+
+      return {
+        data: questionCategories.map(({ data }) => data),
+        meta: {
+          pagination: {
+            page: 1,
+            pageSize: questionCategories.length,
+            pageCount: 1,
+            total: questionCategories.length
+          }
+        }
+      };
+    } catch {
+      ctx.throw(500);
+    }
+  }
+}));

--- a/backend/vaa-strapi/src/api/question-category/routes/00-customRoutes.ts
+++ b/backend/vaa-strapi/src/api/question-category/routes/00-customRoutes.ts
@@ -1,5 +1,5 @@
 /**
- * Contains the definitions for the `api::candidate.answers.overwrite/update` and `api::candidate.properties.update` actions.
+ * Contains the definitions for the `api::question-category.question-category.withRelations` getter.
  * NB. The filename starts with zeros so that it is matched before the core routes.
  */
 

--- a/backend/vaa-strapi/src/api/question-category/routes/00-customRoutes.ts
+++ b/backend/vaa-strapi/src/api/question-category/routes/00-customRoutes.ts
@@ -1,0 +1,20 @@
+/**
+ * Contains the definitions for the `api::candidate.answers.overwrite/update` and `api::candidate.properties.update` actions.
+ * NB. The filename starts with zeros so that it is matched before the core routes.
+ */
+
+import type { Core } from '@strapi/strapi';
+
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/question-categories/with-relations',
+      handler: 'question-category.withRelations',
+      config: {
+        auth: false,
+        policies: []
+      }
+    } as Core.RouteConfig
+  ]
+};

--- a/frontend/src/lib/api/adapters/strapi/dataProvider/strapiDataProvider.ts
+++ b/frontend/src/lib/api/adapters/strapi/dataProvider/strapiDataProvider.ts
@@ -193,7 +193,6 @@ export class StrapiDataProvider extends strapiAdapterMixin(UniversalDataProvider
         }
       }
     };
-
     // If the category has no election defined, it means it applies to all elections
     if (options.electionId)
       params.filters = {
@@ -202,10 +201,6 @@ export class StrapiDataProvider extends strapiAdapterMixin(UniversalDataProvider
           { elections: { documentId: { $null: 'true' } } }
         ]
       };
-    /*
-      
-      
-    */
     const data = await this.apiGet({ endpoint: 'questionCategoriesWithRelations', params });
     const categories = new Array<QuestionCategoryData>();
     const allQuestions = new Map<string, AnyQuestionVariantData>();

--- a/frontend/src/lib/api/adapters/strapi/dataProvider/strapiDataProvider.ts
+++ b/frontend/src/lib/api/adapters/strapi/dataProvider/strapiDataProvider.ts
@@ -193,13 +193,7 @@ export class StrapiDataProvider extends strapiAdapterMixin(UniversalDataProvider
         }
       }
     };
-    /*
-    
-    select *
-    from question_categories
-    join question_categories_constituencies
-    
-    */
+
     // If the category has no election defined, it means it applies to all elections
     if (options.electionId)
       params.filters = {
@@ -212,7 +206,7 @@ export class StrapiDataProvider extends strapiAdapterMixin(UniversalDataProvider
       
       
     */
-    const data = await this.apiGet({ endpoint: 'questionCategories', params });
+    const data = await this.apiGet({ endpoint: 'questionCategoriesWithRelations', params });
     const categories = new Array<QuestionCategoryData>();
     const allQuestions = new Map<string, AnyQuestionVariantData>();
     for (const category of data) {

--- a/frontend/src/lib/api/adapters/strapi/dataProvider/strapiDataProvider.ts
+++ b/frontend/src/lib/api/adapters/strapi/dataProvider/strapiDataProvider.ts
@@ -137,6 +137,10 @@ export class StrapiDataProvider extends strapiAdapterMixin(UniversalDataProvider
   protected async _getNominationData(options: GetNominationsOptions = {}): Promise<DPDataType['nominations']> {
     const locale = options.locale ?? null;
     const params = buildFilterParams(options);
+    if (!options.includeUnconfirmed) {
+      params.filters ??= {};
+      params.filters.unconfirmed = { $ne: 'true' };
+    }
     const data = await this.apiGet({ endpoint: 'nominationsWithRelations', params });
     return parseNominations(data, locale);
   }
@@ -189,6 +193,13 @@ export class StrapiDataProvider extends strapiAdapterMixin(UniversalDataProvider
         }
       }
     };
+    /*
+    
+    select *
+    from question_categories
+    join question_categories_constituencies
+    
+    */
     // If the category has no election defined, it means it applies to all elections
     if (options.electionId)
       params.filters = {
@@ -197,6 +208,10 @@ export class StrapiDataProvider extends strapiAdapterMixin(UniversalDataProvider
           { elections: { documentId: { $null: 'true' } } }
         ]
       };
+    /*
+      
+      
+    */
     const data = await this.apiGet({ endpoint: 'questionCategories', params });
     const categories = new Array<QuestionCategoryData>();
     const allQuestions = new Map<string, AnyQuestionVariantData>();

--- a/frontend/src/lib/api/adapters/strapi/dataProvider/strapiDataProvider.ts
+++ b/frontend/src/lib/api/adapters/strapi/dataProvider/strapiDataProvider.ts
@@ -137,18 +137,7 @@ export class StrapiDataProvider extends strapiAdapterMixin(UniversalDataProvider
   protected async _getNominationData(options: GetNominationsOptions = {}): Promise<DPDataType['nominations']> {
     const locale = options.locale ?? null;
     const params = buildFilterParams(options);
-    params.populate = {
-      constituency: 'true',
-      election: 'true',
-      candidate: {
-        populate: {
-          image: 'true',
-          party: 'true'
-        }
-      },
-      party: { populate: { image: 'true' } }
-    };
-    const data = await this.apiGet({ endpoint: 'nominations', params });
+    const data = await this.apiGet({ endpoint: 'nominationsWithRelations', params });
     return parseNominations(data, locale);
   }
 

--- a/frontend/src/lib/api/adapters/strapi/strapiApi.ts
+++ b/frontend/src/lib/api/adapters/strapi/strapiApi.ts
@@ -29,6 +29,7 @@ export const STRAPI_API: Record<keyof StrapiApiReturnType, string> = {
   constituencyGroups: 'api/constituency-groups',
   elections: 'api/elections',
   nominations: 'api/nominations',
+  nominationsWithRelations: 'api/nominations/with-relations',
   parties: 'api/parties',
   questions: 'api/questions',
   questionTypes: 'api/question-types',
@@ -65,6 +66,7 @@ export type StrapiApiReturnType = {
   constituencyGroups: Array<StrapiConstituencyGroupData>;
   elections: Array<StrapiElectionData>;
   nominations: Array<StrapiNominationData>;
+  nominationsWithRelations: Array<StrapiNominationData>;
   parties: Array<StrapiPartyData>;
   questions: Array<StrapiQuestionData>;
   questionTypes: Array<StrapiQuestionTypeData>;

--- a/frontend/src/lib/api/adapters/strapi/strapiApi.ts
+++ b/frontend/src/lib/api/adapters/strapi/strapiApi.ts
@@ -34,6 +34,7 @@ export const STRAPI_API: Record<keyof StrapiApiReturnType, string> = {
   questions: 'api/questions',
   questionTypes: 'api/question-types',
   questionCategories: 'api/question-categories',
+  questionCategoriesWithRelations: 'api/question-categories/with-relations',
   // FeedbackWriter
   setFeedback: 'api/feedbacks',
   // DataWriter
@@ -71,6 +72,7 @@ export type StrapiApiReturnType = {
   questions: Array<StrapiQuestionData>;
   questionTypes: Array<StrapiQuestionTypeData>;
   questionCategories: Array<StrapiQuestionCategoryData>;
+  questionCategoriesWithRelations: Array<StrapiQuestionCategoryData>;
   // FeedbackWriter
   setFeedback: StrapiFeedbackData;
   // DataWriter

--- a/frontend/src/lib/api/base/getDataOptions.type.ts
+++ b/frontend/src/lib/api/base/getDataOptions.type.ts
@@ -28,8 +28,15 @@ export type GetConstituenciesOptions = GetDataOptionsBase & FilterById;
 /**
  * The options for the `getNominationData` method.
  */
-export type GetNominationsOptions = GetDataOptionsBase & FilterByElection & FilterByConstituency;
-
+export type GetNominationsOptions = GetDataOptionsBase &
+  FilterByElection &
+  FilterByConstituency & {
+    /**
+     * If `true`, include unconfirmed or draft nominations will also be included. They're excluded by default.
+     * This may be useful for preview purposes, but this option should not be used in voter-facing instances.
+     */
+    includeUnconfirmed?: boolean;
+  };
 /**
  * The options for the `getEntityData` method. NB. If the `id` filter is defined, the `entityType` filter must also be defined.
  */


### PR DESCRIPTION
## WHY:

Fixes https://github.com/orgs/OpenVAA/projects/10?pane=issue&itemId=89239431&issue=OpenVAA%7Cvoting-advice-application%7C504

Strapi already adds `BTREE` indexes on all primary and foreign key columns and document ID columns in the relevant tables:
`elections`, `constituencies`, `files_related_mph`, `files`, `parties`, `nominations`, `nominations_election_lnk`, `nominations_constituency_lnk`, `nominations_candidate_lnk`, `candidates`, `candidates_party_lnk`, `nominations_party_lnk`. There isn't much room for further optimization in this area.

However, Strapi’s SQL query generation is somewhat suboptimal. It makes duplicate joins on the same tables, performs multiple `SELECT` queries to support pagination (which we do not benefit from at the moment), and there might be more.

There is a Redis caching plugin available for Strapi 4, but not for Strapi 5.

### What has been changed (if possible, add screenshots, gifs, etc. )

A custom `/api/nominations/with-relations` API endpoint has been added to provide a performance-optimized alternative to the default Strapi `/api/nominations` endpoint.
* In [5cd25fb](https://github.com/OpenVAA/voting-advice-application/pull/717/commits/5cd25fb694d6ef3f718bb36ca6e3026308cd1643), all the same columns as in the original request were selected. However, in [508a32b](https://github.com/OpenVAA/voting-advice-application/pull/717/commits/508a32b17724e22f430571fbf880c2106dce63af) some columns were removed, keeping only those required by the `StrapiNominationData` type to make the response more compact.
* Filtering arguments follow the same format as before, but nominations can only be filtered by election and constituency.

A custom `/api/question-categories/with-relations` API endpoint has been added to provide a performance-optimized alternative to the default Strapi `/api/question-categories` endpoint.
* Filtering arguments follow the same format as before, but question categories can only be filtered by elections.
* This still needs to be tested a bit more to ensure that filtering works as before ❗ 

## Check off each of the following tasks as they are completed

- [ ] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [x] I have run the e2e tests successfully.
- [ ] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have tested my changes using keyboard navigation and screen-reading
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?
- [x] I have cleaned up the commit history and checked the commits follow [the guidelines](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/CONTRIBUTING.md#commit-your-update)