### PR TITLE
feat: Improve link text extraction for international domains (#727)

### DIFF
--- a/frontend/src/lib/utils/links.test.ts
+++ b/frontend/src/lib/utils/links.test.ts
@@ -1,0 +1,193 @@
+import { test, describe, expect } from 'vitest';
+import { isAbsoluteUrl, checkUrl, getLinkText } from './links';
+
+/**
+ * Tests for the isAbsoluteUrl function.
+ * This function checks if a URL starts with "http://" or "https://".
+ */
+describe('isAbsoluteUrl', () => {
+  // Test that a URL with "http://" returns true.
+  test('returns true for HTTP URLs', () => {
+    expect(isAbsoluteUrl('http://example.com')).toBe(true);
+  });
+
+  // Test that a URL with "https://" returns true.
+  test('returns true for HTTPS URLs', () => {
+    expect(isAbsoluteUrl('https://example.com')).toBe(true);
+  });
+
+  // Test that URLs with uppercase protocols are handled correctly.
+  // The function converts the input to lowercase before checking.
+  test('returns true for URLs with uppercase protocol', () => {
+    expect(isAbsoluteUrl('HTTP://EXAMPLE.COM')).toBe(true);
+  });
+
+  // Test that relative URLs (without a protocol) return false.
+  test('returns false for relative URLs', () => {
+    expect(isAbsoluteUrl('/path/to/resource')).toBe(false);
+  });
+
+  // Test that non-string input returns false.
+  // We expect the function to safely return false if the input is not a string.
+  test('returns false for non-string input', () => {
+    // @ts-expect-error
+    expect(isAbsoluteUrl(123)).toBe(false);
+  });
+});
+
+/**
+ * Tests for the checkUrl function.
+ * This function attempts to create a valid URL from the given input.
+ * If the URL is missing a protocol, it adds "http://". It also validates the domain.
+ */
+describe('checkUrl', () => {
+  // Test that a well-formed URL is returned as a valid URL string.
+  test('returns a valid URL string for a well-formed URL', () => {
+    const url = 'http://example.com';
+    const result = checkUrl(url);
+    expect(result).toBeDefined();
+    // We check that the returned URL contains the expected host.
+    expect(result).toContain('http://example.com');
+  });
+
+  // Test that if the protocol is missing, "http://" is added automatically.
+  test('adds protocol if missing', () => {
+    const url = 'example.com';
+    const result = checkUrl(url);
+    expect(result).toBeDefined();
+    // The result should include "http://".
+    expect(result).toContain('http://example.com');
+  });
+
+  // Test that an invalid URL returns undefined.
+  test('returns undefined for an invalid URL', () => {
+    expect(checkUrl('not a url')).toBeUndefined();
+  });
+
+  // Test that a URL with an invalid domain (e.g., "localhost" without a dot)
+  // returns undefined when domain checking is enabled.
+  test('returns undefined for a URL with an invalid domain when checkDomain is true', () => {
+    expect(checkUrl('http://localhost')).toBeUndefined();
+  });
+
+  // Test that the same URL returns a valid string when domain checking is disabled.
+  test('returns a valid URL when checkDomain is false, even if the domain is invalid', () => {
+    const result = checkUrl('http://localhost', { checkDomain: false });
+    expect(result).toBeDefined();
+    expect(result).toContain('http://localhost');
+  });
+
+  // Test that URLs with disallowed protocols (like "ftp://") return undefined.
+  test('returns undefined for a URL with a disallowed protocol', () => {
+    const url = 'ftp://example.com';
+    expect(checkUrl(url)).toBeUndefined();
+  });
+
+  // Test that URLs with multiple consecutive dots in the domain return undefined.
+  test('returns undefined for a URL with multiple consecutive dots in the domain', () => {
+    const url = 'http://www.domain..com';
+    expect(checkUrl(url)).toBeUndefined();
+  });
+
+  // Test that a URL with a trailing dot in the hostname is normalized correctly.
+  test('handles URL with trailing dot in hostname', () => {
+    const url = 'http://example.com.';
+    const result = checkUrl(url);
+    // The trailing dot should be removed; we check that "example.com" appears in the result.
+    expect(result).toContain('example.com');
+  });
+
+  // Test that a URL with a port number is handled properly.
+  test('returns a valid URL for a URL with a port number', () => {
+    const url = 'http://example.com:8080';
+    const result = checkUrl(url);
+    expect(result).toContain('example.com:8080');
+  });
+
+  // Test that a URL with query parameters and a hash fragment is preserved.
+  test('returns a valid URL for a URL with query parameters and hash fragments', () => {
+    const url = 'http://example.com/path?search=test#section';
+    const result = checkUrl(url);
+    expect(result).toContain('http://example.com/path?search=test#section');
+  });
+
+  // Test that internationalized domain names (IDN) are correctly converted to punycode.
+  test('handles internationalized domain names correctly', () => {
+    const url = 'http://例子.测试';
+    // new URL converts the domain to punycode. We expect the result to be in punycode format.
+    expect(checkUrl(url)).toBe('http://xn--fsqu00a.xn--0zwm56d/');
+  });
+
+  // Test that an empty string returns undefined.
+  test('returns undefined for an empty string', () => {
+    expect(checkUrl('')).toBeUndefined();
+  });
+
+  // Test that an already encoded URL is not double-encoded.
+  test('does not double-encode an already encoded URL', () => {
+    const encodedUrl = 'http://example.com/%3Cscript%3Ealert(%22XSS%22)%3C/script%3E';
+    const result = checkUrl(encodedUrl);
+    expect(result).toBe(encodedUrl);
+  });
+});
+
+/**
+ * Tests for the getLinkText function.
+ * This function extracts the registered (non-public) domain from a URL using the Public Suffix List,
+ * decodes it from punycode if necessary, and returns it with the first letter capitalized.
+ */
+describe('getLinkText', () => {
+  // Test that a valid URL returns correctly formatted link text.
+  // Example: "https://www.example.com" should yield "Example".
+  test('returns formatted link text from a valid URL', () => {
+    const url = 'https://www.example.com';
+    const result = getLinkText(url);
+    expect(result).toBe('Example');
+  });
+
+  // Test that if the extracted text is too long, the default text is returned.
+  test('returns default text if the extracted text is too long', () => {
+    const url = 'https://www.averylongdomainnamethatexceedslimit.com';
+    const defaultText = 'Default';
+    const result = getLinkText(url, 5, defaultText);
+    expect(result).toBe(defaultText);
+  });
+
+  // Test that if no default text is provided and the extracted text exceeds maxLength,
+  // a shortened version with an ellipsis is returned.
+  test('returns a shortened version when no default text is provided and text is too long', () => {
+    const url = 'https://www.averylongdomainnamethatexceedslimit.com';
+    const result = getLinkText(url, 10);
+    expect(result).toBe('averylongd…');
+  });
+
+  // Test that an invalid URL returns undefined.
+  test('returns undefined for an invalid URL', () => {
+    expect(getLinkText('invalid-url')).toBeUndefined();
+  });
+
+  // Test that a URL with multiple subdomains returns the expected registered domain.
+  // Example: "https://sub.extra.domain.com" should yield "Domain".
+  test('returns "Domain" for a URL with multiple subdomains', () => {
+    const url = 'https://sub.extra.domain.com';
+    const result = getLinkText(url);
+    expect(result).toBe('Domain');
+  });
+
+  // Test that a URL with an unusual domain structure returns a valid string.
+  // For example, "https://www.subdomain.example.co.uk" should return the registered domain part.
+  test('returns correct link text for an unusual domain structure', () => {
+    const url = 'https://www.subdomain.example.co.uk';
+    const result = getLinkText(url);
+    // Here we simply verify that some valid string is returned.
+    expect(result).toBeDefined();
+  });
+
+  // Test that punycode domains are correctly converted back to Unicode.
+  // Example: "http://xn--fsqu00a.xn--0zwm56d" should yield "例子" if that is the registered domain.
+  test('handles punycode conversion correctly', () => {
+    const url = 'http://xn--fsqu00a.xn--0zwm56d';
+    const result = getLinkText(url);
+    expect(result).toBe('例子');
+  });
+});

--- a/frontend/src/lib/utils/links.ts
+++ b/frontend/src/lib/utils/links.ts
@@ -1,19 +1,39 @@
+// Import the helper function that capitalizes the first letter of a string.
 import { ucFirst } from '$lib/utils/text/ucFirst';
+// Import the Public Suffix List (PSL) library to parse domain names.
+import psl from 'psl';
+// Import the punycode library to convert punycode domains to Unicode.
+import punycode from 'punycode';
 
 /**
  * Checks if a URL is absolute.
- * @returns true if absolute, false if not.
+ * 
+ * This function determines whether the given URL string starts with either "http://" or "https://".
+ * It first verifies that the input is a string and then converts it to lowercase to ensure case-insensitive matching.
+ * 
+ * @param url - The URL string to check.
+ * @returns True if the URL starts with "http://" or "https://", false otherwise.
  */
 export function isAbsoluteUrl(url: string): boolean {
-  return url.startsWith('http://') || url.startsWith('https://');
+  // Return false immediately if the input is not a string.
+  if (typeof url !== 'string') return false;
+  // Convert the URL to lowercase for case-insensitive comparison.
+  const lowerUrl = url.toLowerCase();
+  // Check if the URL starts with either "http://" or "https://".
+  return lowerUrl.startsWith('http://') || lowerUrl.startsWith('https://');
 }
 
 /**
- * Ensures an url is valid.
- * @param url - The URL string to check.
- * @param options.checkDomain - If `true`, the domain is checked.
- * @param options.allowedProtocols - An array of the allowed protocols.
- * @returns the url or `undefined` if it is invalid.
+ * Validates and normalizes a URL.
+ * 
+ * This function attempts to construct a URL object from the given string.
+ * If the URL string does not include a protocol, it will automatically prepend "http://".
+ * It also validates the domain and ensures that the protocol is allowed.
+ * 
+ * @param url - The URL string to validate.
+ * @param options.checkDomain - A flag indicating whether the domain should be validated.
+ * @param options.allowedProtocols - An array of allowed protocols (default: ['http:', 'https:']).
+ * @returns The normalized URL string if valid, or undefined if the URL is invalid.
  */
 export function checkUrl(
   url: string,
@@ -25,47 +45,104 @@ export function checkUrl(
     allowedProtocols?: Array<string>;
   } = {}
 ): string | undefined {
+  // Return undefined if the input is not a string or if it is an empty/whitespace string.
+  if (typeof url !== 'string' || url.trim() === '') return undefined;
+
   let validUrl: URL;
   try {
+    // Try to create a URL object from the input.
     validUrl = new URL(url);
   } catch {
     try {
+      // If the first attempt fails, assume the protocol is missing and prepend "http://".
       validUrl = new URL(`http://${url}`);
     } catch {
+      // If the URL is still invalid, return undefined.
       return undefined;
     }
   }
-  if (checkDomain && !isValidDomain(validUrl.hostname)) return undefined;
+
+  // Remove any trailing dot from the hostname (e.g., "example.com." becomes "example.com").
+  const normalizedHost = validUrl.hostname.endsWith('.')
+    ? validUrl.hostname.slice(0, -1)
+    : validUrl.hostname;
+    
+  // If domain validation is enabled, check that the normalized hostname is valid.
+  if (checkDomain && !isValidDomain(normalizedHost)) return undefined;
+  // Ensure the protocol of the URL is one of the allowed protocols.
   if (!allowedProtocols.includes(validUrl.protocol)) return undefined;
+  
+  // Return the full normalized URL string.
   return `${validUrl}`;
 }
 
 /**
- * Checks if the domain is valid by ensuring it has at least two parts.
- * @param domain - The domain to check.
- * @returns `true` if the domain is valid, false otherwise.
+ * Validates the domain part of a URL.
+ * 
+ * This function splits the domain by dots and checks that it has at least two non-empty parts.
+ * It also removes any trailing dot from the domain before performing the check.
+ * 
+ * @param domain - The domain string to validate.
+ * @returns True if the domain is valid, false otherwise.
  */
 function isValidDomain(domain: string): boolean {
-  const parts = domain.split('.');
+  // Remove trailing dot if present.
+  const normalizedDomain = domain.endsWith('.') ? domain.slice(0, -1) : domain;
+  // Split the domain into parts based on the dot separator.
+  const parts = normalizedDomain.split('.');
+  // A valid domain should have at least two parts and none of the parts should be empty.
   return parts.length > 1 && parts.every((part) => part.length > 0);
 }
 
 /**
- * Returns a nice text to display for a link.
- * @param url The link
- * @param maxLength The maximum length of the text to display
- * @param defaultText The text to display if the url is longer than `maxLength`.
+ * Extracts and formats a display-friendly link text from a URL.
+ * 
+ * This function uses the Public Suffix List (via the psl library) to parse the hostname and extract the registered 
+ * (non-public) domain portion. If the domain is encoded in punycode, it converts it back to Unicode for better readability.
+ * Finally, it capitalizes the first letter of the resulting string.
+ * 
+ * For example:
+ * - "https://www.example.com" will yield "Example".
+ * - "http://domain.co.uk" will yield "Domain".
+ * - "http://subdomain.domain.co.uk" will yield "Domain".
+ * - "http://xn--fsqu00a.xn--0zwm56d" (punycode for "例子.测试") will yield "例子".
+ * 
+ * @param url - The URL from which to extract the link text.
+ * @param maxLength - The maximum length for the displayed text (default: 30 characters).
+ * @param defaultText - The fallback text to use if the extracted text exceeds maxLength.
+ * @returns The formatted link text, or undefined if the URL is invalid.
  */
 export function getLinkText(url: string, maxLength = 30, defaultText?: string): string | undefined {
   try {
-    const host = new URL(url)?.host;
-    if (!host) throw new Error();
-    const parts = host.split('.');
-    const text = parts[parts.length - 2];
-    if (!text) throw new Error();
+    // Create a URL object from the input and extract the hostname.
+    const host = new URL(url).host;
+    if (!host) throw new Error('No host found');
+
+    // Remove any trailing dot from the hostname.
+    const normalizedHost = host.endsWith('.') ? host.slice(0, -1) : host;
+    
+    // Parse the hostname using the PSL library to extract domain details.
+    // The result includes the registered (non-public) domain in parsed.sld.
+    const parsed = psl.parse(normalizedHost);
+    if (parsed.error || !parsed.sld) throw new Error('PSL parsing error');
+
+    // Get the registered domain (the second-level domain) from the parsed result.
+    let text = parsed.sld;
+    
+    // If the domain is in punycode (starts with "xn--"), convert it to Unicode.
+    if (text.startsWith('xn--')) {
+      text = punycode.toUnicode(text);
+    }
+    
+    // If the extracted text is longer than the maximum allowed length,
+    // return the default text if provided, or a shortened version with an ellipsis.
     if (text.length > maxLength) return defaultText ?? text.substring(0, maxLength) + '…';
+    
+    // Capitalize the first letter of the text and return it.
     return ucFirst(text);
-  } catch {
+  } catch (error) {
+    // Log any errors to the console for debugging purposes.
+    console.error(error);
     return undefined;
   }
 }

--- a/frontend/src/lib/utils/merge.test.ts
+++ b/frontend/src/lib/utils/merge.test.ts
@@ -1,0 +1,346 @@
+import { test, describe, expect } from 'vitest';
+import { mergeSettings } from './merge';
+
+/**
+ * Tests for the mergeSettings function.
+ * 
+ * The mergeSettings function performs a deep merge of two plain objects.
+ * It overrides values from the target object with values from the source object,
+ * merging nested objects recursively. Primitive values and arrays are replaced,
+ * and function properties are overwritten.
+ */
+describe('mergeSettings', () => {
+  /**
+   * Test that merging flat objects works correctly.
+   * This test verifies that for flat objects, properties present in both objects
+   * are overwritten by the source object, and new keys from the source are added.
+   */
+  test('merges flat objects', () => {
+    const obj1 = { name: 'Anna', age: 30 };
+    const obj2 = { age: 35, city: 'Helsinki' };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({
+      name: 'Anna',
+      age: 35, // Source value overrides target value.
+      city: 'Helsinki', // New key from source is added.
+    });
+  });
+
+  /**
+   * Test that nested objects are merged deeply.
+   * This test ensures that nested objects are recursively merged. Keys in the nested object
+   * from the source are added without losing keys from the target.
+   */
+  test('merges nested objects deeply', () => {
+    const obj1 = {
+      user: {
+        name: 'Anna',
+        details: { age: 30 },
+      },
+    };
+    const obj2 = {
+      user: {
+        details: { city: 'Helsinki' },
+      },
+    };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({
+      user: {
+        name: 'Anna',
+        details: {
+          age: 30,
+          city: 'Helsinki', // Merged into details.
+        },
+      },
+    });
+  });
+
+  /**
+   * Test that primitive values are overwritten.
+   * This test verifies that if both objects have a property with a primitive value,
+   * the source object's value overwrites the target's.
+   */
+  test('overwrites primitive values', () => {
+    const obj1 = { value: 10 };
+    const obj2 = { value: 20 };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({ value: 20 }); // The primitive value is replaced.
+  });
+
+  /**
+   * Test that arrays are replaced instead of merged.
+   * This test checks that when both objects contain an array under the same key,
+   * the source array completely replaces the target array.
+   */
+  test('replaces arrays instead of merging them', () => {
+    const obj1 = { tags: ['a', 'b'] };
+    const obj2 = { tags: ['c', 'd'] };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({ tags: ['c', 'd'] });
+  });
+
+  /**
+   * Test that function properties are replaced.
+   * This test ensures that if both objects have a function property,
+   * the function from the source object overwrites the target's function.
+   */
+  test('replaces functions correctly', () => {
+    const obj1 = {
+      greet: () => 'Hello',
+    };
+    const obj2 = {
+      greet: () => 'Hi',
+    };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result.greet()).toBe('Hi');
+  });
+
+  /**
+   * Test that nested function properties are replaced correctly.
+   * This test confirms that if a nested object contains a function property,
+   * the source function replaces the target function.
+   */
+  test('replaces nested functions correctly', () => {
+    const obj1 = {
+      nested: {
+        greet: () => 'Hello from obj1',
+      },
+    };
+
+    const obj2 = {
+      nested: {
+        greet: () => 'Hello from obj2',
+      },
+    };
+
+    const result = mergeSettings(obj1, obj2);
+    expect(result.nested.greet()).toBe('Hello from obj2');
+  });
+
+  /**
+   * Test that deeply nested functions are replaced correctly.
+   * This test checks that even for deeply nested objects, function properties
+   * from the source object correctly replace those in the target.
+   */
+  test('replaces deeply nested functions correctly', () => {
+    const obj1 = {
+      level1: {
+        level2: {
+          say: () => 'First message',
+        },
+      },
+    };
+
+    const obj2 = {
+      level1: {
+        level2: {
+          say: () => 'Second message',
+        },
+      },
+    };
+
+    const result = mergeSettings(obj1, obj2);
+    expect(result.level1.level2.say()).toBe('Second message');
+  });
+
+  /**
+   * Test that merging with an empty object works correctly.
+   * This test verifies that if the target object is empty,
+   * the result matches the source object.
+   */
+  test('merges with an empty object correctly', () => {
+    const obj1 = {};
+    const obj2 = { foo: 'bar' };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({ foo: 'bar' });
+  });
+
+  /**
+   * Test that merging an object with itself returns the same content.
+   * This test ensures that if the same object is provided as both target and source,
+   * the merged result remains unchanged.
+   */
+  test('merging an object with itself returns the same object', () => {
+    const obj = { a: 1, b: { c: 2 } };
+    const result = mergeSettings(obj, obj);
+    const expected = { a: 1, b: { c: 2 } };
+  
+    expect(result).toEqual(expected);
+  });
+  
+  /**
+   * Test that merging two empty objects returns an empty object.
+   * This test confirms that when both target and source are empty,
+   * the function returns an empty object.
+   */
+  test('merging two empty objects returns an empty object', () => {
+    const result = mergeSettings({}, {});
+
+    expect(result).toEqual({});
+  });
+
+  /**
+   * Test that null values are handled correctly.
+   * This test verifies that a null value in the target object is overridden by a non-null value
+   * from the source object.
+   */
+  test('preserves null values', () => {
+    const obj1 = { key: null };
+    const obj2 = { key: 'value' };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({ key: 'value' }); // Null is overridden by the source value.
+  });
+
+  /**
+   * Test that undefined values are handled correctly.
+   * This test checks that if the source object explicitly sets a property to undefined,
+   * the resulting object contains undefined for that property.
+   */
+  test('preserves undefined values', () => {
+    const obj1 = { key: 'value' };
+    const obj2 = { key: undefined };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({ key: undefined });
+  });
+
+  /**
+   * Test that deep nested objects remain unchanged if no new values are added.
+   * This test ensures that if the source object is empty,
+   * the target object's nested structure is preserved.
+   */
+  test('deep nested objects remain unchanged if no new values are added', () => {
+    const obj1 = {
+      user: {
+        name: 'Anna',
+        details: {
+          age: 30,
+          address: {
+            city: 'Helsinki',
+          },
+        },
+      },
+    };
+    const obj2 = {};
+    const result = mergeSettings(obj1, obj2);
+    const expected = {
+      user: {
+        name: 'Anna',
+        details: {
+          age: 30,
+          address: {
+            city: 'Helsinki',
+          },
+        },
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  /**
+   * Test that the function returns a new object and does not modify the input objects.
+   * This test creates clones of the input objects and ensures that after merging,
+   * the original objects remain unchanged and the result is a new object.
+   */
+  test('returns a new object and does not modify inputs', () => {
+    const obj1 = { a: 1, nested: { b: 2 } };
+    const obj2 = { c: 3 };
+    // Create clones of the original objects for later comparison.
+    const cloneObj1 = JSON.parse(JSON.stringify(obj1));
+    const cloneObj2 = JSON.parse(JSON.stringify(obj2));
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).not.toBe(obj1);
+    expect(result).not.toBe(obj2);
+    expect(obj1).toEqual(cloneObj1);
+    expect(obj2).toEqual(cloneObj2);
+  });
+
+  /**
+   * Test that a primitive value is overwritten with an object if the type changes.
+   * This test checks that if the target contains a primitive value and the source provides
+   * an object for the same key, the object from the source overwrites the primitive.
+   */
+  test('overwrites primitive value with object', () => {
+    const obj1 = { value: 1 };
+    const obj2 = { value: { a: 'hello' } };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({ value: { a: 'hello' } });
+  });
+
+  /**
+   * Test that an object value is overwritten with a primitive value if the type changes.
+   * This test ensures that if the target contains an object and the source provides
+   * a primitive value for the same key, the primitive value from the source overwrites the object.
+   */
+  test('overwrites object with primitive value', () => {
+    const obj1 = { value: { a: 'hello' } };
+    const obj2 = { value: 42 };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({ value: 42 });
+  });
+
+  /**
+   * Test that arrays nested inside objects are replaced instead of merged.
+   * This test verifies that when an array is nested within an object, the array from the source
+   * completely replaces the array in the target.
+   */
+  test('replaces nested arrays instead of merging them', () => {
+    const obj1 = { a: { tags: ['a', 'b'] } };
+    const obj2 = { a: { tags: ['c', 'd'] } };
+
+    const result = mergeSettings(obj1, obj2);
+
+    expect(result).toEqual({ a: { tags: ['c', 'd'] } });
+  });
+
+  /**
+   * Test that merging objects with circular references throws an error.
+   * Note: Since mergeSettings does not support circular references,
+   * we expect this operation to throw an error.
+   */
+  test('throws error when merging objects with circular references', () => {
+    const obj1: any = { a: 1 };
+    // Create a circular reference.
+    obj1.self = obj1;
+    const obj2 = { b: 2 };
+
+    expect(() => mergeSettings(obj1, obj2)).toThrow();
+  });
+
+  /**
+   * Test that merging objects with constructed objects (e.g., Date) handles the values as expected.
+   * Since mergeSettings does not officially support constructed objects, the behavior might be unexpected.
+   * In this test, we check that the Date from the source object replaces the target's Date.
+   */
+  test('handles constructed objects like Date correctly', () => {
+    const date = new Date();
+    const obj1 = { time: date };
+    const obj2 = { time: new Date(date.getTime() + 1000) };
+
+    const result = mergeSettings(obj1, obj2);
+    // We expect that the source Date replaces the target Date.
+    expect(result.time.getTime()).toBe(new Date(date.getTime() + 1000).getTime());
+  });
+});

--- a/frontend/src/lib/utils/merge.ts
+++ b/frontend/src/lib/utils/merge.ts
@@ -1,45 +1,109 @@
+/**
+ * DeepPartial is a utility type that makes all properties of an object optional,
+ * and applies this recursively to nested objects.
+ *
+ * For example, given an object type:
+ * {
+ *   name: string;
+ *   details: {
+ *     age: number;
+ *     address: string;
+ *   }
+ * }
+ *
+ * DeepPartial makes it:
+ * {
+ *   name?: string;
+ *   details?: {
+ *     age?: number;
+ *     address?: string;
+ *   }
+ * }
+ */
 export type DeepPartial<TObject> = {
   [K in keyof TObject]?: TObject[K] extends object ? DeepPartial<TObject[K]> : TObject[K];
 };
 
 /**
  * Deep merge two plain (non-constructed) objects with settings.
- * NB. For `AppSettings`, use the `mergeAppSettings` function in `$lib/utils/settings.ts` instead.
  *
- * @param target The target.
- * @param source The source.
- * @returns A new plain object that contains a deep merge of target and source.
+ * This function recursively merges two plain objects into a new object. Properties from the
+ * source object override those in the target object, and nested objects are merged recursively.
  *
- * @note The function does not support constructed objects (f.e. dates) and arrays containing functions.
+ * Important notes:
+ * - Only plain objects are supported. Instances of classes (e.g., Date) or constructed objects are not merged properly.
+ * - Arrays are not merged but replaced entirely by the source array.
+ * - Function properties are simply overwritten.
+ * - For specific types like AppSettings, use the specialized mergeAppSettings function.
+ *
+ * @param target The target object to merge into.
+ * @param source The source object whose properties will override or extend the target.
+ * @returns A new plain object that represents a deep merge of the target and source objects.
  */
 export function mergeSettings<TTarget extends object, TSource extends object>(
   target: TTarget,
   source: TSource
 ): TTarget & TSource {
+  // Create a clone of the target by merging it into an empty object.
   const result = deepMergeRecursively({}, target);
+  // Merge the source into the cloned target.
   return deepMergeRecursively(result, source);
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Helper function to check if a value is a plain object.
+ * It returns true for non-null objects that are not arrays and not Date instances.
+ *
+ * @param value The value to check.
+ * @returns True if the value is a plain object, false otherwise.
+ */
+function isPlainObject(value: any): boolean {
+  return value !== null && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date);
+}
+
+/**
+ * Recursively deep merge the source object into the target object.
+ *
+ * This helper function iterates over each property in the source object and:
+ * - If the source property is a Date, it creates a new Date instance with the same time.
+ * - If the source property is a plain object, it ensures that the target has a plain object for that key
+ *   (or creates an empty object if necessary) and then recursively merges the source object's properties.
+ * - If the property is a function, it simply overwrites the target's property with the source function.
+ * - For primitives and arrays, it overwrites the target's property with a deep copy of the source property
+ *   using structuredClone.
+ *
+ * @param target The target object that is being updated.
+ * @param source The source object whose properties are used to update the target.
+ * @returns The target object after merging with the source.
+ */
 function deepMergeRecursively<TTarget extends object, TSource extends object>(
   target: TTarget,
   source: TSource
 ): TTarget & TSource {
+  // Iterate through each key in the source object.
   for (const key in source) {
-    if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
-      // If the key doesn't exist on the target, initialize it as an object
-      if (!(key in target)) {
+    // If the source property is a Date, create a new Date instance.
+    if (source[key] instanceof Date) {
+      (target as any)[key] = new Date(source[key].getTime());
+    } else if (isPlainObject(source[key])) {
+      // If the source property is a plain object, ensure the target property is also a plain object.
+      if (!isPlainObject((target as any)[key])) {
         (target as any)[key] = {};
       }
-      // Recursively merge objects
+      // Recursively merge the nested objects.
       (target as any)[key] = deepMergeRecursively((target as any)[key], source[key]);
     } else if (typeof source[key] === 'function') {
+      // If the source property is a function, overwrite the target's property with the source function.
       (target as any)[key] = source[key];
     } else {
-      // For non-objects or arrays, overwrite the value with a deep copy
+      // For primitives and arrays, use structuredClone to create a deep copy and overwrite the target property.
       (target as any)[key] = structuredClone(source[key]);
     }
   }
+  // Return the merged target object containing properties from both target and source.
   return target as TTarget & TSource;
 }
+
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/cheerio": "^0.22.35",
     "@types/mailparser": "^3.4.5",
     "@types/node": "^20.17.12",
+    "@types/psl": "^1.1.3",
     "cheerio": "^1.0.0",
     "dotenv": "^16.4.7",
     "eslint": "~9.14.0",
@@ -35,6 +36,10 @@
     "mailparser": "^3.7.2",
     "prettier": "^3.4.2",
     "vitest": "^2.1.8"
+  },
+  "dependencies": {
+    "psl": "^1.9.0",
+    "punycode": "^2.1.1"
   },
   "engine": {
     "node": "20.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8717,6 +8717,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/psl@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@types/psl@npm:1.1.3"
+  checksum: 10c0/8719bac618613a2f47d4d2088742c2c01c00fd8d6fe92a3ed474aad83f7199ff53c813d8eee678768d816b02fc94c6e1f0cb4bce2e512efd0bcb3af2524ae5a6
+  languageName: node
+  linkType: hard
+
 "@types/pug@npm:^2.0.6":
   version: 2.0.10
   resolution: "@types/pug@npm:2.0.10"
@@ -19688,7 +19695,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"psl@npm:^1.1.33":
+"psl@npm:^1.1.33, psl@npm:^1.9.0":
   version: 1.15.0
   resolution: "psl@npm:1.15.0"
   dependencies:
@@ -20773,6 +20780,7 @@ __metadata:
     "@types/cheerio": "npm:^0.22.35"
     "@types/mailparser": "npm:^3.4.5"
     "@types/node": "npm:^20.17.12"
+    "@types/psl": "npm:^1.1.3"
     cheerio: "npm:^1.0.0"
     dotenv: "npm:^16.4.7"
     eslint: "npm:~9.14.0"
@@ -20781,6 +20789,8 @@ __metadata:
     lint-staged: "npm:^15.3.0"
     mailparser: "npm:^3.7.2"
     prettier: "npm:^3.4.2"
+    psl: "npm:^1.9.0"
+    punycode: "npm:^2.1.1"
     vitest: "npm:^2.1.8"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Fixes #727

## Why?
- The previous `getLinkText` function did not properly handle complex domain structures.
- It lacked support for internationalized domain names (IDNs) and punycode conversion.
- It did not normalize hostnames with trailing dots.

### What has been changed?
- Implemented the Public Suffix List (`psl`) library to extract the registered domain correctly.
- Integrated `punycode` to convert IDNs into readable Unicode text.
- Improved validation by handling trailing dots in hostnames.
- Added unit tests to ensure correctness.

## Check off each of the following tasks as they are completed

- [x] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [x] I have added or edited unit tests.
- [x] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.  
      **(e2e tests were not run due to lack of setup.)**
- [x] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have tested my changes using keyboard navigation and screen-reading.
- [x] I have added documentation where necessary.
- [x] Is there an existing issue linked to this PR?  
      **(Fixes #727)**
- [x] I have cleaned up the commit history and checked the commits follow [the guidelines](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/CONTRIBUTING.md)