### PR TITLE
fix: Node <22 error in `hasAuthHeaders`

### DIFF
--- a/frontend/src/lib/api/utils/authHeaders.ts
+++ b/frontend/src/lib/api/utils/authHeaders.ts
@@ -7,5 +7,6 @@ const AUTH_HEADERS = ['authorization', 'proxy-authorization'];
  * Check if the given `HeadersInit` contain any authentication credentials.
  */
 export function hasAuthHeaders(headers: HeadersInit | null | undefined): boolean {
-  return new Headers(headers ?? undefined).keys().some((k) => AUTH_HEADERS.includes(k.toLowerCase()));
+  // TODO[Node 22]: Remove Array.from(...)
+  return Array.from(new Headers(headers ?? undefined).keys()).some((k) => AUTH_HEADERS.includes(k.toLowerCase()));
 }


### PR DESCRIPTION
## Check off each of the following tasks as they are completed

- [ ] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [ ] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have tested my changes using keyboard navigation and screen-reading
- [ ] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?
- [ ] I have cleaned up the commit history and checked the commits follow [the guidelines](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/CONTRIBUTING.md#commit-your-update)