### PR TITLE
fix: use normal banner as fallback in dark mode on voter front page

### DIFF
--- a/frontend/src/routes/[[lang=locale]]/(voters)/+page.svelte
+++ b/frontend/src/routes/[[lang=locale]]/(voters)/+page.svelte
@@ -32,7 +32,7 @@ The frontpage of the app for voters.
   pageStyles.push({ drawer: { background: 'bg-base-300' } });
   topBarSettings.push({
     imageSrc: $darkMode
-      ? ($appCustomization.poster?.urlDark ?? '/images/hero.png')
+      ? ($appCustomization.poster?.urlDark ?? $appCustomization.poster?.url ?? '/images/hero.png')
       : ($appCustomization.poster?.url ?? '/images/hero.png')
   });
 </script>


### PR DESCRIPTION
When dark mode banner is not available, now falls back to the normal banner URL before using the default banner image. This matches the behavior already implemented in the candidate login page.

Fixes #821

## WHY:

Fixes [Issue link]

### What has been changed (if possible, add screenshots, gifs, etc. )

## Check off each of the following tasks as they are completed

- [ ] I have reviewed the changes myself in this PR. Please check the [self-review document](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/self-review.md)
- [ ] I have added or edited unit tests.
- [ ] I have run the unit tests successfully.
- [ ] I have run the e2e tests successfully.
- [ ] I have tested this change on my own device.
- [ ] I have tested this change on other devices (Using Browserstack is recommended).
- [ ] I have tested my changes using the [WAVE extension](https://wave.webaim.org/extension/)
- [ ] I have tested my changes using keyboard navigation and screen-reading
- [ ] I have added documentation where necessary.
- [ ] Is there an existing issue linked to this PR?
- [ ] I have cleaned up the commit history and checked the commits follow [the guidelines](https://github.com/OpenVAA/voting-advice-application/blob/main/docs/contributing/CONTRIBUTING.md#commit-your-update)